### PR TITLE
fix(exceptions): log HTTP exception messages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'parcel',
     ],
     dependency_links=[
-        'git+ssh://git@github.com/LabAdvComp/parcel.git@9f2e3bd6769366a1bd99d37fb0971d83e333553e#egg=parcel',
+        'git+ssh://git@github.com/LabAdvComp/parcel.git@c51523de7088208ac6a559283644035f3ea1ea7b#egg=parcel',
     ],
     scripts=[
         'bin/gdc-client',


### PR DESCRIPTION
- raise_for_status doesn't return the content of the response when
  raising an exception.
- Use version of parcel that fixes this issue.
