### PR TITLE
feat(requirements): adds a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-e git+https://github.com/LabAdvComp/parcel.git@c51523de7088208ac6a559283644035f3ea1ea7b#egg=parcel 
+.


### PR DESCRIPTION
This just adds a requirements file for installation via pip. There is already a [parcel pypi package](https://pypi.python.org/pypi/parcel/0.1.1), which combined w/ `dependency_links` not being respected, can cause the wrong version of parcel to be installed. If you've run into the `HTTPClient` import error, it's because of that.

@NCI-GDC/ucdevs thoughts?
