### PR TITLE
fix(logging): s/stdout/stderr/g

### DIFF
--- a/gdc_client/log.py
+++ b/gdc_client/log.py
@@ -15,12 +15,12 @@ def get_logger(name='gdc-client'):
         return loggers[name]
     log = logging.getLogger(name)
     log.propagate = False
-    if sys.stdout.isatty():
+    if sys.stderr.isatty():
         formatter = logging.Formatter(
             colored('%(asctime)s: %(levelname)s: ', 'blue')+'%(message)s')
     else:
         formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(formatter)
     log.addHandler(handler)
     loggers[name] = log


### PR DESCRIPTION
This just replaces `stdout` with `stderr` as the default logging file handle. This is in conjunction w/ https://github.com/LabAdvComp/parcel/pull/72 that does the same for parcel and together should cause logging to default to stderr for `gdc-client`.

Ideally these should be rewritten to have some top-level code identify a file handle and configure the loggers to use that. It'll require more work, though.

@millerjs @madopal r?
