### PR TITLE
feat(parser): migrates interactive to subparser

### DIFF
--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -3,8 +3,8 @@ import logging
 import sys
 
 from gdc_client.version import __version__ as version
-from gdc_client.argparser import argparser
-from gdc_client import download, upload
+from gdc_client.argparser import argparser, subparsers
+from gdc_client import download, upload, interactive
 from gdc_client.log import get_logger
 
 logging.root.setLevel(logging.INFO)
@@ -23,32 +23,30 @@ def log_version_header():
 
 
 def run_command(args):
+
+    # NOTE this if clause only here because of download / upload
+    if args.func is not None:
+        return args.func(args)
+
     commands_callbacks[args.command](False)
 
 
-def print_help():
-    print "usage: gdc-client [upload/download/interactive] [arguments]"
-    print "       upload - mode to upload files (without args to get help)"
-    print "       download - mode to download files (without args to get help)"
-    print "       interactive - runs in interactive mode for both download or upload (arguments ignored)"
-
-def main():
-    if not sys.argv[1:]:
-        # If no subcommand was specified use default command
-        print_help()
-        return
-        #return DEFAULT_COMMAND()
-    if sys.argv[1] == "interactive":
-        sys.argv.remove("interactive")
-        commands_callbacks[download.command](True)
-    else:
-        args = argparser.parse_args()
-        log_version_header()
-        run_command(args)
-
-
 if __name__ == '__main__':
+
+    argparser.set_defaults(func=None)
+
+    interactive_subparser = subparsers.add_parser('interactive',
+        help='run in interactive mode',
+    )
+    interactive.parser.config(interactive_subparser)
+
+    # TODO add download subparser
+    # TODO add upload subparser
+
+    args = argparser.parse_args()
+    log_version_header()
+
     try:
-        main()
+        run_command(args)
     except KeyboardInterrupt:
         print('\nProcess canceled by user.')

--- a/gdc_client/download/__init__.py
+++ b/gdc_client/download/__init__.py
@@ -3,7 +3,6 @@ import sys
 import logging
 
 from . import client
-from ..repl import run_repl
 from .. import defaults
 from ..argparser import subparsers
 from parcel import manifest, const
@@ -122,20 +121,17 @@ def print_help():
     subparser.print_help()
 
 def main(interactive):
-    if interactive:
-        run_repl()
-    else:
-        args = subparser.parse_args()
-        if args.verbose:
-            logging.root.setLevel(logging.DEBUG)
+    args = subparser.parse_args()
+    if args.verbose:
+        logging.root.setLevel(logging.DEBUG)
 
-        try:
-            run_cli(args)
-        except Exception as e:
-            if args.debug:
-                raise
-            else:
-                print('Process aborted: {}'.format(str(e)))
+    try:
+        run_cli(args)
+    except Exception as e:
+        if args.debug:
+            raise
+        else:
+            print('Process aborted: {}'.format(str(e)))
 
     # If there are arguments other than subcommand, run cli
     #if sys.argv[2:]:

--- a/gdc_client/interactive/__init__.py
+++ b/gdc_client/interactive/__init__.py
@@ -1,0 +1,1 @@
+from . import parser

--- a/gdc_client/interactive/parser.py
+++ b/gdc_client/interactive/parser.py
@@ -1,0 +1,18 @@
+import sys
+import argparse
+
+from . import repl
+
+
+def interactive(args):
+    """ Initiates an interactive REPL.
+    """
+    # TODO use any inherited top-level args
+    r = repl.GDCREPL()
+    r.prompt = '\ngdc-client >> '
+    r.cmdloop()
+
+def config(parser):
+    """ Configure a parser for interactive REPL.
+    """
+    parser.set_defaults(func=interactive)

--- a/gdc_client/interactive/repl.py
+++ b/gdc_client/interactive/repl.py
@@ -428,31 +428,3 @@ class GDCREPL(Cmd):
 
         """
         self.do_help(arg)
-
-def run_repl():
-    r = GDCREPL()
-    r.prompt = '\ngdc-client repl > '
-    r.cmdloop()
-
-
-
-
-def main():
-   run_repl()
-   # args = subparsers.parse_args()
-   # if args.verbose:
-   #     logging.root.setLevel(logging.DEBUG)
-
-    # If there are arguments other than subcommand, run cli
-   # if sys.argv[2:]:
-   #     try:
-   #         run_cli(args)
-   #     except Exception as e:
-   #         if args.debug:
-   #             raise
-   #         else:
-   #             print('Process aborted: {}'.format(str(e)))
-
-    # Else, run as a repl
-   # else:
-


### PR DESCRIPTION
This moves the interactive shell into a subcommand of the client and moves subparser configuration away from being a side effect of imports. It follows a convention of registering a callback `func` which takes as input a single argument, which is the argparse parsed arguments namespace.

@NCI-GDC/ucdevs thoughts?
