### PR TITLE
feat(client): adds context manager

### DIFF
--- a/gdc_client/auth/__init__.py
+++ b/gdc_client/auth/__init__.py
@@ -1,0 +1,1 @@
+from .auth import GDCTokenAuth

--- a/gdc_client/auth/auth.py
+++ b/gdc_client/auth/auth.py
@@ -1,0 +1,12 @@
+import requests
+
+
+class GDCTokenAuth(requests.auth.AuthBase):
+    """ GDC Token Authentication
+    """
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r):
+        r.headers['X-Auth-Token'] = self.token
+        return r

--- a/gdc_client/client/__init__.py
+++ b/gdc_client/client/__init__.py
@@ -1,0 +1,1 @@
+from .client import GDCClient

--- a/gdc_client/client/client.py
+++ b/gdc_client/client/client.py
@@ -1,0 +1,55 @@
+from contextlib import closing
+from contextlib import contextmanager
+
+import requests
+
+from .. import auth
+
+
+GDC_API_HOST = 'gdc-api.nci.nih.gov'
+GDC_API_PORT = 443
+
+class GDCClient(object):
+    """ GDC API Requests Client
+    """
+    def __init__(self, host=GDC_API_HOST, port=GDC_API_PORT, token=None):
+        self.host = host
+        self.port = port
+        self.token = token
+
+        self.session = requests.Session()
+
+    @contextmanager
+    def request(self, verb, path, **kwargs):
+        """ Make a request to the GDC API.
+        """
+        res = self.session.request(verb,
+            'https://{host}:{port}{path}'.format(
+                host=self.host,
+                port=self.port,
+                path=path,
+            ),
+            auth=auth.GDCTokenAuth(self.token),
+            **kwargs
+        )
+
+        with closing(res):
+            yield res
+
+    def get(self, path, **kwargs):
+        return self.request('GET', path, **kwargs)
+
+    def put(self, path, **kwargs):
+        return self.request('PUT', path, **kwargs)
+
+    def post(self, path, **kwargs):
+        return self.request('POST', path, **kwargs)
+
+    def head(self, path, **kwargs):
+        return self.request('HEAD', path, **kwargs)
+
+    def patch(self, path, **kwargs):
+        return self.request('PATCH', path, **kwargs)
+
+    def delete(self, path, **kwargs):
+        return self.request('DELETE', path, **kwargs)


### PR DESCRIPTION
This adds a requests / session context manager and GDC token auth module for making requests to the GDC API. This is mostly for handling long-lived streams (`download` / `upload` / `slice`) as expected w/ general client usage, but also gives a central location to add any GDC-specific hooks / parameters / etc that we want across all client requests, for example token auth.

The main thing this does is ensure that a `close` call is made on responses. This tries to help prevent any long-lived `stream=True` requests from sitting open and eating up connections. Using this for instance with large data downloads (`stream=True`), requests to the GDC API would look like:

``` python
client = GDCClient(token='some_token')

with client.get('/data/some_uuid', stream=True) as res:
    # ...do something with res...
```

Everything else should function as usual w.r.t normal requests usage within a session.

Note that at present nothing uses this - it's my intention to run at least the slicing logic off of this if it's merged in. Otherwise I'll just build it using the requests module directly.

@NCI-GDC/ucdevs thoughts?
