### PR TITLE
fix(logging): fixes logger creation

### DIFF
--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -5,7 +5,6 @@ import logging
 import sys
 
 from gdc_client import download, upload, interactive
-from gdc_client.log import get_logger
 from gdc_client.exceptions import ClientError
 
 from gdc_client import log
@@ -13,6 +12,8 @@ from gdc_client import auth
 from gdc_client import client
 from gdc_client import version
 
+
+logger = log.get_logger()
 
 DESCRIPTION = '''
 The Genomic Data Commons Command Line Client
@@ -29,7 +30,6 @@ ERROR_MSG = ' '.join([
 
 
 def log_version_header():
-    logger = log.get_logger()
     logger.info('gdc-client - {version}'.format(version=version.__version__))
 
 
@@ -89,14 +89,14 @@ if __name__ == '__main__':
     try:
         args.func(args)
     except ClientError as err:
-        log.error(err)
+        logger.error(err)
         sys.exit(1)
     except KeyboardInterrupt:
-        log.warning('Process cancelled by user.')
+        logger.warning('Process cancelled by user.')
         sys.exit(130)
     except Exception as err:
-        log.error(ERROR_MSG)
-        log.exception(err)
+        logger.error(ERROR_MSG)
+        logger.exception(err)
         sys.exit(1)
     else:
-        log.info('Completed successfully.')
+        logger.info('Completed successfully.')


### PR DESCRIPTION
I messed up a merge conflict patch during merging #30 to `develop`. Basically just dropped `logger` creation and a naming conflict.

@NCI-GDC/ucdevs r?
