### PR TITLE
feat(token): adds token command

### DIFF
--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -4,7 +4,7 @@ import argparse
 import logging
 import sys
 
-from gdc_client import download, upload, interactive
+from gdc_client import token, download, upload, interactive
 from gdc_client.log import get_logger
 from gdc_client.exceptions import ClientError
 
@@ -61,6 +61,12 @@ if __name__ == '__main__':
         dest='command',
         help='for more information, specify -h after a command',
     )
+
+    token_subparser = subparsers.add_parser('token',
+        parents=[template],
+        help='log in and generate an auth token',
+    )
+    token.parser.config(token_subparser)
 
     download_subparser = subparsers.add_parser('download',
         parents=[template],

--- a/gdc_client/token/__init__.py
+++ b/gdc_client/token/__init__.py
@@ -1,0 +1,1 @@
+from . import parser

--- a/gdc_client/token/parser.py
+++ b/gdc_client/token/parser.py
@@ -1,0 +1,93 @@
+import argparse
+import urlparse
+
+import requests
+
+# Because this is such beautiful...
+from bs4 import BeautifulSoup as bs
+
+
+try:
+    import http.client as http_client
+except ImportError:
+    # Python 2
+    import httplib as http_client
+http_client.HTTPConnection.debuglevel = 1
+
+def token(args):
+    """ Generate and / or retrieve a GDC auth token.
+    """
+    session = requests.Session()
+    session.keep_alive = False
+
+    # GET GDC session and find ourselves an eRA session.
+    res = session.head('https://gdc-portal.nci.nih.gov/auth/',
+        allow_redirects=True,
+    )
+    res.raise_for_status()
+
+    # Extract the eRA session information from query string args...
+    url = urlparse.urlparse(res.url)
+    qs = urlparse.parse_qs(url[4])
+
+    # TODO parse these from form hidden inputs
+    data = {
+        'SMLOCALE': 'US-EN',
+        'SMENC': 'ISO-8859-1',
+        'smquerydata': '',
+        'smagentname': '-SM-itrusteauth.nih.gov',
+        'postpreservationdata': '',
+        'target': qs['TARGET'],
+        'minloa': 'NIHIssuedLOA4',
+    }
+
+    # Inject eRA credentials.
+    data['USER'] = args.username
+    data['PASSWORD'] = args.password
+
+    # Validate against eRA w/ the above...
+    res = session.post('https://itrusteauth.nih.gov/siteminderagent/forms/login.fcc',
+        data=data,
+    )
+    res.raise_for_status()
+
+    # Forward the SAML response to the GDC API for validation...
+    soup = bs(res.text, 'html.parser')
+    saml = soup.input['value']
+
+    data = {
+        'SAMLResponse': saml,
+    }
+
+    res = session.post('https://gdc-portal.nci.nih.gov/auth/Shibboleth.sso/SAML2/POST',
+        data=data,
+    )
+    res.raise_for_status()
+
+    # And finally, GET the GDC auth token from API.
+    res = session.get('https://gdc-portal.nci.nih.gov/auth/token')
+    res.raise_for_status()
+
+    # TA-DAAA! You've got a GDC auth token via command line...
+    print(res.text)
+
+    # ...I'm going to sleep now...
+
+def config(parser):
+    """ Configure a parser for token generation.
+    """
+    parser.set_defaults(func=token)
+
+    parser.add_argument('-u', '--username',
+        required=True,
+        help='eRA username',
+    )
+
+    # FIXME TODO UT FACIAM REMOVE THIS BEFORE USE
+    # ===========================================
+    # we don't want plain-text passwords being stored in logs
+    # consider using a password file or interactive prompt
+    parser.add_argument('-p', '--password',
+        required=True,
+        help='eRA password',
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
--e git+https://github.com/LabAdvComp/parcel.git@aba9e1eef1cdda4e6ce22927593c66971a121878#egg=parcel 
+-e git+https://github.com/LabAdvComp/parcel.git@aba9e1eef1cdda4e6ce22927593c66971a121878#egg=parcel
+beautifulsoup4>=4.0.0
 .

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,9 @@ setup(
     packages=find_packages(),
     package_data={},
     install_requires=[
-        'parcel',
         'lxml==3.5.0b1',
         'PyYAML==3.11',
         'setuptools==19.2'
-    ],
-    dependency_links=[
-        'git+https://github.com/LabAdvComp/parcel.git@aba9e1eef1cdda4e6ce22927593c66971a121878#egg=parcel',
     ],
     scripts=[
         'bin/gdc-client',


### PR DESCRIPTION
**NOTE Do not merge without significant refactoring!**
(how I make this red?)

This adds an eRA / GDC authentication and token generation command to the client. It's very messy at the moment and needs some work before it should be considered for merging, but I wanted to get this out there and visible since, if included, it would prolly be the most dangerous piece of the client - sending around eRA creds and all that.

Right now it takes as input an eRA `username` and `password`, both of which are plain text and will end up in, for example, shell history. This is far from desirable, and would either need to be an interactive prompt for the `password` _at least_, or take in a credentials file that stores the eRA creds.

Unfortunately, I'm not yet certain about what is guaranteed on the eRA login forms and what is subject to change, so some of the endpoints and form inputs are hardcoded. The hidden input fields for the eRA login should be extracted from query string arguments, as is being done by the `target` right now, if possible, and parsing / interpretation of the login form should be handled better than just throwing it at beautiful soup.

There's also a bug with urllib3 that seems to come up w/ the massive chain of redirects that happen w/ itrustauth. It appears to be of the same vein as the same bug that's been showing up in some areas of our ES requests and tests. So it may take multiple (read: many) attempts before the whole slew of requests go through without an error.

@NCI-GDC/ucdevs thoughts?
