### PR TITLE
chore(config): set default processes to 1

### DIFF
--- a/gdc_client/defaults.py
+++ b/gdc_client/defaults.py
@@ -17,7 +17,7 @@ udt_url = 'https://gdc-parcel.nci.nih.gov/'
 ####################
 
 # The number of processes used to download data files
-processes = 8
+processes = 1
 
 ####################
 # UDT Proxy settings


### PR DESCRIPTION
As per the title (and apparently a newline at the EOF). Addresses [PGDC-2119](https://jira.opensciencedatacloud.org/browse/PGDC-2119).

@NCI-GDC/ucdevs r?
