### PR TITLE
Feat/user agent

### DIFF
--- a/gdc_client/client/client.py
+++ b/gdc_client/client/client.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import requests
 
 from .. import auth
+from .. import version
 
 
 GDC_API_HOST = 'gdc-api.nci.nih.gov'
@@ -20,7 +21,7 @@ class GDCClient(object):
         self.session = requests.Session()
 
         agent = ' '.join([
-            'GDC-Client',
+            'GDC-Client/{version}'.format(version=version.__version__),
             self.session.headers.get('User-Agent', 'Unknown'),
         ])
 


### PR DESCRIPTION
This adds a default `User-Agent` header to all client requests made via the request context manager. This builds upon the default `User-Agent` that `requests` adds in order to maintain information about the client environment. Prolly unnecessary, but if there is no default `User-Agent` header for the session, a value of `Unknown` is used.

I'm thinking we could use this to distinguish non-client traffic from other `requests`-based traffic.

@NCI-GDC/ucdevs r?
