### PR TITLE
fix(checkpoint): bumps save interval to 1GB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/LabAdvComp/parcel.git@aba9e1eef1cdda4e6ce22927593c66971a121878#egg=parcel 
+-e git+https://github.com/LabAdvComp/parcel.git@f947376f90161c41c2d39997e3e95a007ca77042#egg=parcel 
 .


### PR DESCRIPTION
Bumps the version of parcel used which bumps the checkpoint interval.

See https://github.com/LabAdvComp/parcel/pull/77 for details.

@BedfordWest 
@NCI-GDC/ucdevs r?
