### PR TITLE
fix(download): bumps parcel for segment retry fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/LabAdvComp/parcel.git@f947376f90161c41c2d39997e3e95a007ca77042#egg=parcel 
+-e git+https://github.com/LabAdvComp/parcel.git@f4bf13929ed5ba43f7d26034cd02bb8d9329b50a#egg=parcel 
 .

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'setuptools==19.2'
     ],
     dependency_links=[
-        'git+https://github.com/LabAdvComp/parcel.git@aba9e1eef1cdda4e6ce22927593c66971a121878#egg=parcel',
+        'git+https://github.com/LabAdvComp/parcel.git@f4bf13929ed5ba43f7d26034cd02bb8d9329b50a#egg=parcel',
     ],
     scripts=[
         'bin/gdc-client',


### PR DESCRIPTION
As per the title, bumps the parcel hash to use the segment retry fix.

@allisonheath 
@BedfordWest 
@NCI-GDC/ucdevs r?
