### PR TITLE
chore(auth): adds platform-specific instructions

### DIFF
--- a/gdc_client/auth/parser.py
+++ b/gdc_client/auth/parser.py
@@ -8,8 +8,8 @@ from contextlib import closing
 
 
 PLATFORM_HELP = {
-    'Darwin': 'On OS X: chmod 500 {token_file}',
-    'Linux': 'On Linux: chmod 500 {token_file}',
+    'Darwin': 'On OS X: chmod 600 {token_file}',
+    'Linux': 'On Linux: chmod 600 {token_file}',
 }
 
 PLATFORM_HELP_DEFAULT = 'Contact your system administrator for assistance.'


### PR DESCRIPTION
This adds platform-specific instructions to the secure-your-token message. The default message is set to be a generic 'contact your administrator', with more specific instructions for OS X and linux. I'm kind of on the fence about even including those, as it seems like this is important enough that, if the user doesn't already know how to secure their token on their system, a more experienced person should either instruct or do it for them.

@NCI-GDC/ucdevs thoughts?
