### PR TITLE
fix(upload): revert parser verification

### DIFF
--- a/gdc_client/upload/parser.py
+++ b/gdc_client/upload/parser.py
@@ -14,22 +14,10 @@ from .client import GDCUploadClient
 def validate_args(parser, args):
     """ Validate argparse namespace.
     """
-    if args.manifest:
+    if args.manifest or args.identifier:
         return
 
-    if all([
-        args.project_id,
-        args.identifier,
-        args.path,
-    ]): return
-
-    these = ', '.join([
-        '--project-id',
-        '--identifier',
-        '--path',
-    ])
-
-    msg = 'must specify either --manifest or {these}'.format(these=these)
+    msg = 'must specify either --manifest or --identifier'
     parser.error(msg)
 
 


### PR DESCRIPTION
This reverts a parse-time check that requires a project id and file path be specified when an identifier is provided.

@BedfordWest 
@msfitzsimons 
@NCI-GDC/ucdevs r?
