### PR TITLE
fix(args): Makes upload/download more consistent

### DIFF
--- a/gdc_client/download/parser.py
+++ b/gdc_client/download/parser.py
@@ -96,7 +96,7 @@ def config(parser):
                         help='The TCP server address server[:port]')
     parser.add_argument('--no-segment-md5sums', dest='segment_md5sums',
                         action='store_false',
-                        help='Calculate inbound segment md5sums and/or verify md5sums on restart')
+                        help="Don't calculate inbound segment md5sums and/or don't verify md5sums on restart")
     parser.add_argument('--no-file-md5sum', dest='file_md5sum',
                         action='store_false',
                         help="Don't verify file md5sum after download")
@@ -144,5 +144,5 @@ def config(parser):
     parser.add_argument('file_ids',
         metavar='file_id',
         nargs='*',
-        help='GDC files to download',
+        help='The GDC UUID of the file(s) to download',
     )

--- a/gdc_client/interactive/repl.py
+++ b/gdc_client/interactive/repl.py
@@ -17,7 +17,7 @@ class GDCREPL(Cmd):
 
     HEADER = """
     Type 'help' for a list of commands or 'help <topic>' for detailed usage.
-    """.format(version=__version__)
+    """
 
     BASIC_HELP = """Basic help:
     This tool is for downloading data from the GDC.  A few simple usage examples:

--- a/gdc_client/log/log.py
+++ b/gdc_client/log/log.py
@@ -6,6 +6,43 @@ from parcel import colored
 loggers = {}
 
 
+class LogFormatter(logging.Formatter):
+
+    err_format  = colored('ERROR: ', 'red') + '%(msg)s'
+    warn_format  = colored('WARNING: ', 'yellow') + '%(msg)s'
+    dbg_format  = colored('%(asctime)s - DEBUG: %(module)s: %(lineno)d: ', 'blue') + '%(msg)s'
+    info_format = '%(asctime)s - INFO: %(msg)s'
+
+
+    def __init__(self, fmt='%(asctime)s - %(levelname)s: %(msg)s'):
+        logging.Formatter.__init__(self, fmt)
+
+
+    def format(self, record):
+
+        # Save the original format
+        format_orig = self._fmt
+
+        # Replace the original format with one customized by logging level
+        if record.levelno == logging.DEBUG:
+            self._fmt = LogFormatter.dbg_format
+
+        elif record.levelno == logging.INFO:
+            self._fmt = LogFormatter.info_format
+
+        elif record.levelno == logging.WARNING:
+            self._fmt = LogFormatter.warn_format
+
+        elif record.levelno == logging.ERROR:
+            self._fmt = LogFormatter.err_format
+
+        result = logging.Formatter.format(self, record)
+
+        # Restore the original format
+        self._fmt = format_orig
+
+        return result
+
 # Logging
 def get_logger(name='gdc-client'):
     """Create or return an existing logger with given name
@@ -16,8 +53,7 @@ def get_logger(name='gdc-client'):
     log = logging.getLogger(name)
     log.propagate = False
     if sys.stderr.isatty():
-        formatter = logging.Formatter(
-            colored('%(asctime)s: %(levelname)s: ', 'blue')+'%(message)s')
+        formatter = LogFormatter()
     else:
         formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
     handler = logging.StreamHandler(sys.stderr)

--- a/gdc_client/log/parser.py
+++ b/gdc_client/log/parser.py
@@ -13,7 +13,7 @@ def setup_logging(args):
 def config(parser):
     """ Configure an argparse parser for logging.
     """
-    parser.set_defaults(log_levels=[logging.ERROR])
+    parser.set_defaults(log_levels=[logging.WARNING])
 
     parser.add_argument('--debug',
         action='append_const',

--- a/gdc_client/upload/parser.py
+++ b/gdc_client/upload/parser.py
@@ -9,15 +9,21 @@ from . import manifest
 from . import exceptions
 
 from .client import GDCUploadClient
+from .. import log
 
+
+logger = log.get_logger('upload-client')
 
 def validate_args(parser, args):
     """ Validate argparse namespace.
     """
-    if args.manifest or args.identifier:
+    if args.identifier:
+        logger.warn('The use of the -i/--identifier flag has been deprecated.')
+
+    if args.manifest or args.file_ids:
         return
 
-    msg = 'must specify either --manifest or --identifier'
+    msg = 'must specify either --manifest or file_id'
     parser.error(msg)
 
 
@@ -29,17 +35,18 @@ def upload(parser, args):
     files = read_manifest(args.manifest) if args.manifest else []
 
     if not args.manifest:
-        files.append({
-            'id': args.identifier,
-            'project_id': args.project_id,
-            'path': args.path,
-            'upload_id': args.upload_id,
-        })
+        for uuid in args.file_ids:
+            files.append({
+                'id': uuid,
+                'project_id': args.project_id,
+                'path': args.path,
+                'upload_id': args.upload_id,
+            })
 
     # TODO remove debug - handled by logger
     debug = logging.DEBUG in args.log_levels
 
-    manifest_name = args.manifest.name if args.manifest else args.identifier
+    manifest_name = args.manifest.name if args.manifest else args.file_ids[0]
 
     client = GDCUploadClient(
         token=args.token_file, processes=args.n_processes,
@@ -62,8 +69,6 @@ def config(parser):
 
     parser.add_argument('--project-id', '-p', type=str,
                         help='The project ID that owns the file')
-    parser.add_argument('--identifier', '-i', type=str,
-                        help='The file id')
     parser.add_argument('--path', '-f', metavar='path',
                         help='directory path to find file')
     parser.add_argument('--upload-id', '-u',
@@ -95,7 +100,12 @@ def config(parser):
     parser.add_argument('--delete',
                         action="store_true",
                         help='Delete an uploaded file')
-
     parser.add_argument('--manifest', '-m',
                         type=argparse.FileType('r'),
                         help='Manifest which describes files to be uploaded')
+    parser.add_argument('--identifier', '-i', action='store_true',
+                        help='DEPRECATED')
+    parser.add_argument('file_ids',
+                        metavar='file_id', type=str,
+                        nargs='*',
+                        help='The GDC UUID of the file(s) to upload')


### PR DESCRIPTION
Updated the way the upload accepts arguments to make it more
consistent with download
Allows upload (and deletion) or multiple files
Warns the user if they are using the deprecated -i flag
Created a new LogFormatter class to better format the logs
Now use different colors and format for different log level
Also changed default log level to WARNING
Also fixed some help messages

This addresses DTT-20 and DTT-11