### PR TITLE
fixed handshake bug that made requests not work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 -e git+https://github.com/LabAdvComp/parcel.git@fddae5c09283ee5058fb9f43727a97a253de31fb#egg=parcel
 .
+pyOpenSSL==16.2.0
+ndg-httpsclient==0.4.2


### PR DESCRIPTION
I had a bug that would error on an openssl handshake whenever I tried to download. Installing these libraries fixes that problem.


Error message:
```
./bin/gdc-client download 22a29915-6712-4f7a-8dba-985ae9a1f005
2016-10-27 11:31:10,856: ERROR: Unable to download 22a29915-6712-4f7a-8dba-985ae9a1f005: Unable to conne
ct to API: ([SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:590)). Is this ur
l correct: 'https://gdc-api.nci.nih.gov/data/'? Is there a connection to the API? Is the server running?

SUMMARY:
Failed to download: 1

ERROR: 22a29915-6712-4f7a-8dba-985ae9a1f005: Unable to connect to API: ([SSL: SSLV3_ALERT_HANDSHAKE_FAIL
URE] sslv3 alert handshake failure (_ssl.c:590)). Is this url correct: 'https://gdc-api.nci.nih.gov/data
/'? Is there a connection to the API? Is the server running?
```

@NCI-GDC/ucdevs r?