### PR TITLE
Added file logging

### DIFF
--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -7,13 +7,11 @@ import sys
 from gdc_client import download, upload, interactive
 from gdc_client.exceptions import ClientError
 
-from gdc_client import log
+from gdc_client import log as logger
 from gdc_client import auth
 from gdc_client import client
 from gdc_client import version
 
-
-logger = log.get_logger()
 
 DESCRIPTION = '''
 The Genomic Data Commons Command Line Client
@@ -29,8 +27,8 @@ ERROR_MSG = ' '.join([
 ]).format(support_email=SUPPORT_EMAIL)
 
 
-def log_version_header():
-    logger.info('gdc-client - {version}'.format(version=version.__version__))
+def log_version_header(log):
+    log.info('gdc-client - {version}'.format(version=version.__version__))
 
 
 if __name__ == '__main__':
@@ -51,7 +49,7 @@ if __name__ == '__main__':
         add_help=False,
     )
 
-    log.parser.config(template)
+    logger.parser.config(template)
     auth.parser.config(template)
     client.parser.config(template)
 
@@ -83,20 +81,32 @@ if __name__ == '__main__':
     # Parse and run.
     args = parser.parse_args()
 
-    log.setup_logging(args)
-    log_version_header()
+    logger.setup_logging(args)
+    logger.logger_filename = args.log_file.name
+
+
+    log = logger.get_logger()
+
+    log_version_header(log)
+
+    download.parser.setup_logger('gdc-client')
+    upload.parser.setup_logger('upload')
 
     try:
+        # go
         args.func(args)
     except ClientError as err:
-        logger.error(err)
+        log.error(err)
         sys.exit(1)
     except KeyboardInterrupt:
-        logger.warning('Process cancelled by user.')
+        log.warning('Process cancelled by user.')
         sys.exit(130)
     except Exception as err:
-        logger.error(ERROR_MSG)
-        logger.exception(err)
+        log.error(ERROR_MSG)
+        log.exception(err)
+        log.error('Exiting')
         sys.exit(1)
     else:
-        logger.info('Completed successfully.')
+        # will hit this branch even if downloads fail
+        # and debug is turned off
+        log.info('gdc-client exited normally')

--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -82,15 +82,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     logger.setup_logging(args)
-    logger.logger_filename = args.log_file.name
 
-
-    log = logger.get_logger()
-
+    log = logging.getLogger('gdc-client')
     log_version_header(log)
-
-    download.parser.setup_logger('gdc-client')
-    upload.parser.setup_logger('upload')
 
     try:
         # go

--- a/gdc_client/auth/parser.py
+++ b/gdc_client/auth/parser.py
@@ -1,6 +1,6 @@
 import os
 import stat
-import logging
+from .. import log as logger
 import argparse
 import platform
 
@@ -24,7 +24,7 @@ PERMISSIONS_MSG = ' '.join([
 def read_token_file(path):
     """ Safely open, read and close a token file.
     """
-    log = logging.getLogger('gdc-client')
+    log = logger.get_logger('gdc-client')
 
     # TODO review best way to check file security on various platforms
 

--- a/gdc_client/auth/parser.py
+++ b/gdc_client/auth/parser.py
@@ -1,6 +1,6 @@
 import os
 import stat
-from .. import log as logger
+import logging
 import argparse
 import platform
 
@@ -24,7 +24,7 @@ PERMISSIONS_MSG = ' '.join([
 def read_token_file(path):
     """ Safely open, read and close a token file.
     """
-    log = logger.get_logger('gdc-client')
+    log = logging.getLogger('gdc-client')
 
     # TODO review best way to check file security on various platforms
 

--- a/gdc_client/download/client.py
+++ b/gdc_client/download/client.py
@@ -8,9 +8,9 @@ from parcel import HTTPClient, UDTClient, utils
 from parcel.download_stream import DownloadStream
 from ..query.index import GDCIndexClient
 
-from .. import log as logger
+import logging
 
-log = logger.get_logger('gdc-client')
+log = logging.getLogger('gdc-download')
 
 class GDCDownloadMixin(object):
 

--- a/gdc_client/download/client.py
+++ b/gdc_client/download/client.py
@@ -6,13 +6,11 @@ import urlparse
 
 from parcel import HTTPClient, UDTClient, utils
 from parcel.download_stream import DownloadStream
-from ..log import get_logger
 from ..query.index import GDCIndexClient
 
-# Logging
-log = get_logger('download-client')
-log.propagate = False
+from .. import log as logger
 
+log = logger.get_logger('gdc-client')
 
 class GDCDownloadMixin(object):
 

--- a/gdc_client/download/parser.py
+++ b/gdc_client/download/parser.py
@@ -7,12 +7,12 @@ from parcel import const
 from parcel import manifest
 
 from .. import defaults
-from .. import log as logger
+import logging
 from .client import GDCUDTDownloadClient
 from .client import GDCHTTPDownloadClient
 
 
-log = None
+log = logging.getLogger('gdc-download')
 
 UDT_SUPPORT = ' '.join([
     'UDT is supported through the use of the Parcel UDT proxy.',
@@ -204,6 +204,3 @@ def config(parser):
     )
 
 
-def setup_logger(name='gdc-client'):
-    global log
-    log = logger.get_logger(name)

--- a/gdc_client/download/parser.py
+++ b/gdc_client/download/parser.py
@@ -1,20 +1,18 @@
 import argparse
-import logging
+import logging # needed for logging.DEBUG flag
 import time
 
 from functools import partial
-
 from parcel import const
 from parcel import manifest
 
 from .. import defaults
 from .. import log as logger
-
 from .client import GDCUDTDownloadClient
 from .client import GDCHTTPDownloadClient
 
 
-log = logging.getLogger('gdc-client')
+log = None
 
 UDT_SUPPORT = ' '.join([
     'UDT is supported through the use of the Parcel UDT proxy.',
@@ -204,3 +202,8 @@ def config(parser):
         nargs='*',
         help='The GDC UUID of the file(s) to download',
     )
+
+
+def setup_logger(name='gdc-client'):
+    global log
+    log = logger.get_logger(name)

--- a/gdc_client/log/__init__.py
+++ b/gdc_client/log/__init__.py
@@ -1,4 +1,3 @@
-from .log import get_logger
 from .parser import setup_logging
 
 from . import parser

--- a/gdc_client/log/log.py
+++ b/gdc_client/log/log.py
@@ -3,10 +3,6 @@ import sys
 
 from parcel import colored
 
-
-loggers = {}
-logger_filename = ''
-
 class LogFormatter(logging.Formatter):
 
     err_format  = colored('ERROR: ', 'red') + '%(msg)s'
@@ -43,38 +39,4 @@ class LogFormatter(logging.Formatter):
         self._fmt = format_orig
 
         return result
-
-
-def get_logger(name='gdc-client'):
-    """Create or return an existing logger with given name
-    """
-
-    # logger already exists
-    if name in loggers:
-        if len(loggers[name].handlers) < 2 and logger_filename:
-            loggers[name].addHandler(logging.FileHandler(logger_filename))
-
-        return loggers[name]
-
-    # need a new logger
-    logger = logging.getLogger(name)
-    logger.propagate = False
-
-    if sys.stderr.isatty():
-        formatter = LogFormatter()
-    else:
-        formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
-
-    stream_handler = logging.StreamHandler(sys.stderr)
-    stream_handler.setFormatter(formatter)
-
-    logger.addHandler(stream_handler)
-
-    if logger_filename and logger_filename != sys.stderr:
-        file_handler = logging.FileHandler(logger_filename)
-        logger.addHandler(file_handler)
-
-    # store it for when we request a new logger
-    loggers[name] = logger
-    return logger
 

--- a/gdc_client/log/parser.py
+++ b/gdc_client/log/parser.py
@@ -1,8 +1,10 @@
 import argparse
+import log
 import logging
 import sys
 
 from .. import version
+
 
 
 def setup_logging(args):
@@ -10,27 +12,36 @@ def setup_logging(args):
     """
     logging.root.setLevel(min(args.log_levels))
 
+    # this will apply to any logging done independantly of get_logger()
+    if args.log_file and args.log_file != sys.stderr:
+        logger_filename = args.log_file.name
+
+        logging.basicConfig(filename=logger_filename)
+        log.logger_filename = logger_filename
+
 def config(parser):
     """ Configure an argparse parser for logging.
     """
+
     parser.set_defaults(log_levels=[logging.WARNING])
 
     parser.add_argument('--debug',
         action='append_const',
         dest='log_levels',
         const=logging.DEBUG,
-        help='enable debug logging',
+        help='Enable debug logging. If a failure occurs, the program will stop.',
     )
 
     parser.add_argument('-v', '--verbose',
         action='append_const',
         dest='log_levels',
         const=logging.INFO,
-        help='enable verbose logging',
+        help='Enable verbose logging',
     )
 
     parser.add_argument('--log-file',
+        dest='log_file',
         type=argparse.FileType('a'),
         default=sys.stderr,
-        help='log file [stderr]',
+        help='Save logs to file. Amount logged affected by --debug, and --verbose flags',
     )

--- a/gdc_client/log/parser.py
+++ b/gdc_client/log/parser.py
@@ -5,6 +5,7 @@ import sys
 
 from .. import version
 
+from .log import LogFormatter
 
 
 def setup_logging(args):
@@ -12,12 +13,21 @@ def setup_logging(args):
     """
     logging.root.setLevel(min(args.log_levels))
 
-    # this will apply to any logging done independantly of get_logger()
     if args.log_file and args.log_file != sys.stderr:
         logger_filename = args.log_file.name
 
-        logging.basicConfig(filename=logger_filename)
-        log.logger_filename = logger_filename
+    if sys.stderr.isatty():
+        formatter = LogFormatter()
+    else:
+        formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
+
+
+    logging.basicConfig(
+            level=min(args.log_levels),
+            filename=logger_filename,
+            formatter=formatter)
+
+    log.logger_filename = logger_filename
 
 def config(parser):
     """ Configure an argparse parser for logging.

--- a/gdc_client/query/index.py
+++ b/gdc_client/query/index.py
@@ -1,10 +1,6 @@
 import requests
 from urlparse import urljoin
 
-from ..log import get_logger
-
-# Logging
-log = get_logger('query')
 
 
 class GDCIndexClient(object):
@@ -45,3 +41,4 @@ class GDCIndexClient(object):
             r = requests.get(url, verify=False, params=params)
             r.raise_for_status()
         return r.json()
+

--- a/gdc_client/upload/client.py
+++ b/gdc_client/upload/client.py
@@ -16,9 +16,11 @@ from progressbar import ProgressBar, Percentage, Bar
 from collections import deque
 import time
 import copy
-from ..log import get_logger
 
 from . import manifest
+from .. import log as logger
+
+log = logger.get_logger('upload')
 
 MAX_RETRIES = 10
 MAX_TIMEOUT = 60
@@ -45,8 +47,6 @@ else:
     from mmap import ACCESS_READ
 
 
-log = get_logger('upload-client')
-log.propagate = False
 
 
 def upload_multipart_wrapper(args):

--- a/gdc_client/upload/client.py
+++ b/gdc_client/upload/client.py
@@ -18,9 +18,9 @@ import time
 import copy
 
 from . import manifest
-from .. import log as logger
+import logging
 
-log = logger.get_logger('upload')
+log = logging.getLogger('upload')
 
 MAX_RETRIES = 10
 MAX_TIMEOUT = 60

--- a/gdc_client/upload/parser.py
+++ b/gdc_client/upload/parser.py
@@ -1,4 +1,5 @@
 import argparse
+# needed for logging.DEBUG flag
 import logging
 
 from functools import partial
@@ -9,16 +10,16 @@ from . import manifest
 from . import exceptions
 
 from .client import GDCUploadClient
-from .. import log
+from .. import log as logger
 
 
-logger = log.get_logger('upload-client')
+log = None
 
 def validate_args(parser, args):
     """ Validate argparse namespace.
     """
     if args.identifier:
-        logger.warn('The use of the -i/--identifier flag has been deprecated.')
+        log.warn('The use of the -i/--identifier flag has been deprecated.')
 
     if not args.token_file:
         parser.error('A token is required in order to upload.')
@@ -111,3 +112,9 @@ def config(parser):
                         metavar='file_id', type=str,
                         nargs='*',
                         help='The GDC UUID of the file(s) to upload')
+
+
+def setup_logger(name='upload-client'):
+    global log
+    log = logger.get_logger(name)
+    log.propagate = False

--- a/gdc_client/upload/parser.py
+++ b/gdc_client/upload/parser.py
@@ -10,10 +10,10 @@ from . import manifest
 from . import exceptions
 
 from .client import GDCUploadClient
-from .. import log as logger
+import logging
 
 
-log = None
+log = logging.getLogger('gdc-upload')
 
 def validate_args(parser, args):
     """ Validate argparse namespace.
@@ -112,9 +112,3 @@ def config(parser):
                         metavar='file_id', type=str,
                         nargs='*',
                         help='The GDC UUID of the file(s) to upload')
-
-
-def setup_logger(name='upload-client'):
-    global log
-    log = logger.get_logger(name)
-    log.propagate = False


### PR DESCRIPTION
Rearranged code that wasn't using the get_logger func
modified imports to be more uniform

`--log-file LOG_FILE` can be used in conjunction with `--verbose` or `--debug` to affect the amount of details written to a file.

@NCI-GDC/ucdevs r?

It should also be known that this does not interact with any of the logging functionality that parcel handles. I'm not sure if that should be a consideration. Please advise.