### PR TITLE
fixed bug where the user would enter a full path, and resume would fail

### DIFF
--- a/gdc_client/upload/client.py
+++ b/gdc_client/upload/client.py
@@ -120,6 +120,21 @@ def get_sleep_time(tries):
     return timeout * (0.5 + random.random()/2)
 
 
+def create_resume_path(file_path):
+    ''' in case the user enters a path, you want to create
+    a resume_filename.yml inside the same directory as the manifest.yml
+    '''
+
+    # check if it's a path or just a filename
+    if os.path.dirname(file_path):
+    # 2.6 compatible
+        return "{0}/resume_{1}".format(
+            os.path.dirname(file_path), os.path.basename(file_path))
+
+    # just a filename
+    return 'resume_' + file_path
+
+
 class GDCUploadClient(object):
 
     def __init__(self, token, processes, server, part_size,

--- a/tests/test_upload_client.py
+++ b/tests/test_upload_client.py
@@ -1,0 +1,22 @@
+
+from unittest import TestCase
+
+from gdc_client.upload.client import create_resume_path
+
+class UploadClientTest(TestCase):
+    def setup(self):
+        pass
+
+    def test_create_resume_path(self):
+        # don't need to test if there's no file given
+        # that is checked in multipart_upload()
+        tests = [
+                '/path/to/file.yml',
+                'path/to/file.yml',
+                'file.yml']
+        results =[
+                '/path/to/resume_file.yml',
+                'path/to/resume_file.yml',
+                'resume_file.yml']
+        for i, t in enumerate(tests):
+            assert create_resume_path(t) == results[i]


### PR DESCRIPTION
added a function to fix resume_path
added a test for the fix

Fixed a bug when a user would enter a path to a manifest.yml file.

https://github.com/NCI-GDC/gdc-client/blob/feat/python-26/gdc_client/upload/client.py#L148

This line just prepends 'resume_' to the path.