### PR TITLE
fix(logging): dtt now dumps logs from parcel to a file if --log-file …

### DIFF
--- a/gdc_client/log/parser.py
+++ b/gdc_client/log/parser.py
@@ -11,29 +11,26 @@ from .log import LogFormatter
 def setup_logging(args):
     """ Set up logging given parsed logging arguments.
     """
-    logging.root.setLevel(min(args.log_levels))
 
-    if args.log_file and args.log_file != sys.stderr:
-        logger_filename = args.log_file.name
+    f_formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
 
-    if sys.stderr.isatty():
-        formatter = LogFormatter()
-    else:
-        formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
+    root = logging.getLogger()
+    root.setLevel(min(args.log_levels))
 
+    s_handler = logging.StreamHandler(sys.stdout)
+    s_handler.setFormatter(LogFormatter())
+    root.addHandler(s_handler)
 
-    logging.basicConfig(
-            level=min(args.log_levels),
-            filename=logger_filename,
-            formatter=formatter)
+    f_handler = logging.FileHandler(args.log_file.name)
+    f_handler.setFormatter(f_formatter)
+    root.addHandler(f_handler)
 
-    log.logger_filename = logger_filename
 
 def config(parser):
     """ Configure an argparse parser for logging.
     """
 
-    parser.set_defaults(log_levels=[logging.WARNING])
+    parser.set_defaults(log_levels=[logging.INFO])
 
     parser.add_argument('--debug',
         action='append_const',
@@ -42,12 +39,15 @@ def config(parser):
         help='Enable debug logging. If a failure occurs, the program will stop.',
     )
 
+    '''
+    # verbose by default now
     parser.add_argument('-v', '--verbose',
         action='append_const',
         dest='log_levels',
         const=logging.INFO,
         help='Enable verbose logging',
     )
+    '''
 
     parser.add_argument('--log-file',
         dest='log_file',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/LabAdvComp/parcel.git@fddae5c09283ee5058fb9f43727a97a253de31fb#egg=parcel
+-e git+https://github.com/LabAdvComp/parcel.git@04a2307992bf026be27e68fe01402c93e27e3873#egg=parcel
 setuptools==19.2
 pyOpenSSL==16.2.0
 ndg-httpsclient==0.4.2


### PR DESCRIPTION
…is used

So now the DTT captures all logging to a file if the user requests it.

@NCI-GDC/ucdevs r?

This change depends on https://github.com/LabAdvComp/parcel/pull/92