### PR TITLE
[feat][DTT-30]: Feat/dtt 30 feedback from ian

### DIFF
--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -9,7 +9,9 @@ from gdc_client.exceptions import ClientError
 from gdc_client import log as logger
 from gdc_client import auth
 from gdc_client import version
-from gdc_client.common.config import GDCClientConfigShared
+from gdc_client.common.config import (
+    GDCClientConfigShared, GDCClientArgumentParser
+)
 
 
 ####################################################
@@ -42,7 +44,7 @@ def log_version_header(log):
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser(
+    parser = GDCClientArgumentParser(
         description=DESCRIPTION,
     )
 
@@ -61,7 +63,7 @@ if __name__ == '__main__':
     # Generate template parser for use by all sub-commands. This will
     # contain any shared, top-level arguments and flags that will be
     # needed by most, if not all, subcommands.
-    template = argparse.ArgumentParser(
+    template = GDCClientArgumentParser(
         add_help=False,
     )
 

--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -89,7 +89,7 @@ if __name__ == '__main__':
     upload.parser.config(upload_subparser, config_loader.to_dict('upload'))
 
     settings_subparser = subparsers.add_parser(
-        'settings', parents=[template], help='display default settings')
+        'settings', help='display default settings')
     settings.parser.config(settings_subparser, conf_parser_args.config)
 
     # Parse and run.

--- a/gdc_client/common/config.py
+++ b/gdc_client/common/config.py
@@ -5,7 +5,11 @@ from gdc_client.defaults import (
     processes, USER_DEFAULT_CONFIG_LOCATION, HTTP_CHUNK_SIZE
 )
 
-log = logging.getLogger('gdc-client-config')
+log = logging.getLogger('gdc-client')
+
+# This will display the default configs in a INI-type format, so that users
+# will be able to copy and modify as needed
+DISPLAY_TEMPLATE = '[{}]\n{}\n'
 
 
 class GDCClientConfigShared(object):
@@ -56,7 +60,6 @@ class GDCClientConfigShared(object):
                 'no_auto_retry': False,
                 'retry_amount': 1,
                 'wait_time': 5.0,
-                'manifest': [],
             },
             'upload': {
                 'path': '.',
@@ -98,5 +101,8 @@ class GDCClientConfigShared(object):
     def to_display_string(self, section):
         _config = self.to_dict(section)
 
-        return '\n'.join(' = '.join([key, str(val)])
-                         for key, val in _config.items())
+        return DISPLAY_TEMPLATE.format(
+            section,
+            '\n'.join(' = '.join([key, str(val)])
+            for key, val in _config.items())
+        )

--- a/gdc_client/common/config.py
+++ b/gdc_client/common/config.py
@@ -1,4 +1,6 @@
+import argparse
 import logging
+import sys
 from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 
 from gdc_client.defaults import (
@@ -10,6 +12,17 @@ log = logging.getLogger('gdc-client')
 # This will display the default configs in a INI-type format, so that users
 # will be able to copy and modify as needed
 DISPLAY_TEMPLATE = '[{}]\n{}\n'
+
+
+class GDCClientArgumentParser(argparse.ArgumentParser):
+    """This is a workaround introduced here https://groups.google.com/forum/#!topic/argparse-users/LazV_tEQvQw
+    which enables to print the full help message in case something went wrong
+    with argument parsing
+    """
+    def error(self, message):
+        self.print_help(sys.stderr)
+        sys.stderr.write('\ngdc-client error: {}\n'.format(message))
+        sys.exit(2)
 
 
 class GDCClientConfigShared(object):

--- a/gdc_client/download/parser.py
+++ b/gdc_client/download/parser.py
@@ -279,6 +279,7 @@ def config(parser, download_defaults):
     '''
     parser.add_argument('-m', '--manifest',
         type=manifest.argparse_type,
+        default=[],
         help='GDC download manifest file',
     )
     parser.add_argument('file_ids',

--- a/gdc_client/log/parser.py
+++ b/gdc_client/log/parser.py
@@ -16,12 +16,10 @@ def setup_logging(args):
     color_off = args.color_off if hasattr(args, 'color_off') else False
     log_file = args.log_file if hasattr(args, 'log_file') else None
 
-    logging.root.setLevel(log_level)
     root = logging.getLogger()
+    root.setLevel(log_level)
 
     f_formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
-
-    root.setLevel(log_level)
 
     s_handler = logging.StreamHandler(sys.stdout)
     s_handler.setFormatter(LogFormatter(color_off=color_off))
@@ -34,6 +32,7 @@ def setup_logging(args):
 
     # the requests library has it's own log statements, and it bundles itself without asking
     logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
 
 
 def config(parser):

--- a/gdc_client/log/parser.py
+++ b/gdc_client/log/parser.py
@@ -11,21 +11,24 @@ from .log import LogFormatter
 def setup_logging(args):
     """ Set up logging given parsed logging arguments.
     """
+    log_level = (
+        min(args.log_levels) if hasattr(args, 'log_levels') else logging.INFO)
+    color_off = args.color_off if hasattr(args, 'color_off') else False
+    log_file = args.log_file if hasattr(args, 'log_file') else None
 
-    logging.root.setLevel(min(args.log_levels))
+    logging.root.setLevel(log_level)
     root = logging.getLogger()
 
     f_formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
 
-    root = logging.getLogger()
-    root.setLevel(min(args.log_levels))
+    root.setLevel(log_level)
 
     s_handler = logging.StreamHandler(sys.stdout)
-    s_handler.setFormatter(LogFormatter(color_off=args.color_off))
+    s_handler.setFormatter(LogFormatter(color_off=color_off))
     root.addHandler(s_handler)
 
-    if args.log_file:
-        f_handler = logging.FileHandler(args.log_file.name)
+    if log_file:
+        f_handler = logging.FileHandler(log_file.name)
         f_handler.setFormatter(f_formatter)
         root.addHandler(f_handler)
 

--- a/gdc_client/settings/parser.py
+++ b/gdc_client/settings/parser.py
@@ -3,8 +3,7 @@ from functools import partial
 
 from gdc_client.common.config import GDCClientConfigShared
 
-
-log = logging.getLogger('gdc-settings')
+logger = logging.getLogger('gdc-client')
 
 HELP = (
     'Path to INI-type config file. See what settings will look like if a custom'
@@ -16,34 +15,24 @@ class SettingsResolver(object):
     def __init__(self, config_file):
         self.config = GDCClientConfigShared(config_file)
 
-    def ls(self, section, args):
-        log.info(self.config.to_display_string(section))
-        return self.config.to_display_string(section)
+    def download(self):
+        logger.info(self.config.to_display_string('download'))
+        return self.config.to_display_string('download')
 
-    def show(self, section, args):
-        return self.ls(section, args)
+    def upload(self):
+        logger.info(self.config.to_display_string('upload'))
+        return self.config.to_display_string('upload')
 
 
-def resolve(section, config_file, args):
+def resolve(config_file, args):
     resolver = SettingsResolver(config_file)
-    command = args.command
-    func = getattr(resolver, command)
-    return func(section, args)
+    func = getattr(resolver, args.section)
+    return func()
 
 
 def config(parser, config_file=None):
-    sub_parsers = parser.add_subparsers(
-        title='sub commands', dest='sub'
-    )
+    parser.add_argument('section', choices=['download', 'upload'])
+    parser.add_argument('--config', help=HELP, metavar='FILE')
 
-    upload_resolver = partial(resolve, 'upload', config_file)
-    upload = sub_parsers.add_parser('upload')
-    upload.add_argument('command', choices=['show', 'ls'])
-    upload.add_argument('--config', help=HELP)
-    upload.set_defaults(func=upload_resolver)
-
-    download_resolver = partial(resolve, 'download', config_file)
-    download = sub_parsers.add_parser('download')
-    download.add_argument('command', choices=['show', 'ls'])
-    download.add_argument('--config', help=HELP)
-    download.set_defaults(func=download_resolver)
+    resolver = partial(resolve, config_file)
+    parser.set_defaults(func=resolver)

--- a/gdc_client/settings/parser.py
+++ b/gdc_client/settings/parser.py
@@ -31,8 +31,13 @@ def resolve(config_file, args):
 
 
 def config(parser, config_file=None):
-    parser.add_argument('section', choices=['download', 'upload'])
     parser.add_argument('--config', help=HELP, metavar='FILE')
+    choices = parser.add_subparsers(title='Settings to display', dest='section')
 
-    resolver = partial(resolve, config_file)
-    parser.set_defaults(func=resolver)
+    download_choice = choices.add_parser('download', help='Display download settings')
+    download_choice.add_argument('--config', help=HELP, metavar='FILE')
+    download_choice.set_defaults(func=partial(resolve, config_file))
+
+    upload_choice = choices.add_parser('upload', help='Display upload settings')
+    upload_choice.add_argument('--config', help=HELP, metavar='FILE')
+    upload_choice.set_defaults(func=partial(resolve, config_file))


### PR DESCRIPTION
* Remove parent parsers for `settings` sub parser (no need for `--token` etc). Refactor settings
* Change the way settings are displayed. Now the output matches an `INI`-type config file
* Override `ArgumentParser.error` to display full help message in addition to default error message