### PR TITLE
fix(dtt-121): add pre-check for latest files

### DIFF
--- a/gdc_client/download/parser.py
+++ b/gdc_client/download/parser.py
@@ -1,16 +1,17 @@
-import argparse
 import logging
 import time
 import urlparse
 from functools import partial
 
-from gdc_client.download.client import GDCUDTDownloadClient
-from gdc_client.download.client import GDCHTTPDownloadClient
-from gdc_client.query.index import GDCIndexClient
-from gdc_client.utils import build_url
-from parcel import colored
-from parcel import manifest
+from parcel import colored, manifest
 
+from gdc_client.download.client import (
+    GDCHTTPDownloadClient,
+    GDCUDTDownloadClient,
+)
+from gdc_client.query.index import GDCIndexClient
+from gdc_client.query.versions import get_latest_versions
+from gdc_client.utils import build_url
 
 log = logging.getLogger('gdc-download')
 
@@ -93,14 +94,18 @@ def download(parser, args):
             break
         ids.add(i['id'])
 
+    # Query the api to get the latest version of a file according to the gdc.
+    # Replace the old list of uuids with the potentially newer list of uuids,
+    # then proceed with the rest of the program as normal.
+    if args.latest:
+        log.info('Downloading LATEST versions of files')
+        ids = get_latest_versions(args.server, ids)
+
     index_client = GDCIndexClient(args.server)
     client = get_client(args, index_client)
 
     # separate the smaller files from the larger files
     bigs, smalls = index_client.separate_small_files(ids, args.http_chunk_size)
-
-    if args.latest:
-        log.info('Downloading LATEST versions of files')
 
     # the big files will be normal downloads
     # the small files will be joined together and tarfiled
@@ -108,15 +113,14 @@ def download(parser, args):
         log.debug('Downloading smaller files...')
 
         # download small file grouped in an uncompressed tarfile
-        small_errors, count = client.download_small_groups(smalls, args.latest)
+        small_errors, count = client.download_small_groups(smalls)
         successful_count += count
 
         i = 0
         while i < args.retry_amount and small_errors:
             time.sleep(args.wait_time)
             log.debug('Retrying failed grouped downloads')
-            small_errors, count = client.download_small_groups(small_errors,
-                                                               args.latest)
+            small_errors, count = client.download_small_groups(small_errors)
             successful_count += count
             i += 1
 
@@ -126,7 +130,7 @@ def download(parser, args):
         log.debug('Downloading big files...')
 
         # create URLs to send to parcel for download
-        params = ('latest',) if args.latest else ()
+        params = ()
         bigs = [
             urlparse.urljoin(client.data_uri, build_url(b, *params))
             for b in bigs
@@ -287,4 +291,3 @@ def config(parser, download_defaults):
         nargs='*',
         help='The GDC UUID of the file(s) to download',
     )
-

--- a/gdc_client/query/index.py
+++ b/gdc_client/query/index.py
@@ -1,9 +1,8 @@
+import logging
+from json import dumps
 from urlparse import urljoin
 
-import logging
 import requests
-from json import dumps
-
 
 log = logging.getLogger('query')
 
@@ -106,11 +105,11 @@ class GDCIndexClient(object):
         }
 
         metadata_query = {
-            'fields': 'file_id,file_size,md5sum,annotations.annotation_id,' \
+            'fields': 'file_id,file_size,md5sum,annotations.annotation_id,'
                       'metadata_files.file_id,index_files.file_id,access',
             'filters': dumps(filters),
             'from': '0',
-            'size': str(len(uuids)), # one big request
+            'size': str(len(uuids)),  # one big request
         }
 
         active_meta_url = urljoin(self.uri, self.active_meta_endpoint)
@@ -121,7 +120,7 @@ class GDCIndexClient(object):
 
         if not active_hits and not legacy_hits:
             log.debug('Unable to retrieve file metadata information. '
-                        'continuing downloading as if they were large files')
+                      'continuing downloading as if they were large files')
             return self.metadata
 
         for h in active_hits + legacy_hits:

--- a/gdc_client/query/versions.py
+++ b/gdc_client/query/versions.py
@@ -1,0 +1,55 @@
+"""gdc_client.query.versions
+
+Functionality related to versioning.
+"""
+import requests
+
+
+def get_latest_versions(url, uuids):
+    """Get the latest version of a UUID according to the api.
+
+    Args:
+        url (str):
+        uuids (list): list of UUIDs that might have a new version
+
+    Returns:
+        list: list of uuids with potentially new versions
+    """
+
+    versions_url = url + '/files/versions'
+    latest_versions = []
+
+    # Make multiple queries in an attempt to balance the load on the server.
+    for chunk in _chunk_list(uuids):
+        resp = requests.post(versions_url, json={'ids': chunk})
+
+        # Parse the results of the chunked query.
+        for result in resp.json():
+            # Probably wouldn't happen, but just in case add an error check.
+            uuid = result.get('latest_id')
+            if uuid:
+                latest_versions.append(uuid)
+
+    return latest_versions
+
+
+def _chunk_list(elements, chunk_size=500):
+    """Chunk any list into smaller parts.
+
+    Args:
+        elements (list): list of elements
+        chunk_size (int): max number of elements in the resulting chunk
+
+    Returns:
+        list: list of lists containing chunked workloads
+    """
+
+    chunks = [[]]
+    chunk_number = 0
+    for element in elements:
+        if len(chunks[chunk_number]) >= chunk_size:
+            chunks.append([])
+            chunk_number += 1
+        chunks[-1].append(element)
+
+    return chunks

--- a/gdc_client/query/versions.py
+++ b/gdc_client/query/versions.py
@@ -34,22 +34,17 @@ def get_latest_versions(url, uuids):
 
 
 def _chunk_list(elements, chunk_size=500):
-    """Chunk any list into smaller parts.
+    """Generator to chunk any list into smaller parts.
 
     Args:
         elements (list): list of elements
         chunk_size (int): max number of elements in the resulting chunk
 
     Returns:
-        list: list of lists containing chunked workloads
+        generator: generator yielding chunked workloads
     """
 
-    chunks = [[]]
-    chunk_number = 0
-    for element in elements:
-        if len(chunks[chunk_number]) >= chunk_size:
-            chunks.append([])
-            chunk_number += 1
-        chunks[-1].append(element)
-
-    return chunks
+    current_index = 0
+    while current_index < len(elements):
+        yield elements[current_index:current_index + chunk_size]
+        current_index += chunk_size

--- a/tests/test_download_client.py
+++ b/tests/test_download_client.py
@@ -1,17 +1,18 @@
-from conftest import md5, uuids, make_tarfile
-from gdc_client.download.client import GDCHTTPDownloadClient
-from gdc_client.query.index import GDCIndexClient
-from multiprocessing import Process, cpu_count
-from parcel.const import HTTP_CHUNK_SIZE, SAVE_INTERVAL
-from unittest import TestCase
-
 import logging
-import mock_server
 import os
 import os.path
 import StringIO
 import tarfile
 import time
+from multiprocessing import Process, cpu_count
+from unittest import TestCase
+
+from parcel.const import HTTP_CHUNK_SIZE, SAVE_INTERVAL
+
+import mock_server
+from conftest import make_tarfile, md5, uuids
+from gdc_client.download.client import GDCHTTPDownloadClient
+from gdc_client.query.index import GDCIndexClient
 
 # default values for flask
 server_host = 'http://127.0.0.1'
@@ -127,7 +128,7 @@ class DownloadClientTest(TestCase):
                 **client_kwargs)
 
         # it will remove redundant uuids
-        tarfile_name, errors = client._download_tarfile(files_to_dl, False)
+        tarfile_name, errors = client._download_tarfile(files_to_dl)
 
         assert tarfile_name != None
         assert os.path.exists(tarfile_name)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,11 +1,14 @@
-from conftest import md5, uuids
-from gdc_client.query.index import GDCIndexClient
+import time
 from multiprocessing import Process
-from parcel.const import HTTP_CHUNK_SIZE
 from unittest import TestCase
 
+import pytest
+from parcel.const import HTTP_CHUNK_SIZE
+
 import mock_server
-import time
+from conftest import uuids
+from gdc_client.query.index import GDCIndexClient
+from gdc_client.query.versions import _chunk_list
 
 # default values for flask
 server_host = 'http://127.0.0.1'
@@ -219,3 +222,14 @@ class QueryIndexTest(TestCase):
 
         assert bigs == ['big_no_friends']
         assert smalls == [['small_no_friends']]
+
+
+@pytest.mark.parametrize("case", [
+    range(1),
+    range(499),
+    range(500),
+    range(1000),
+])
+def test_chunk_list(case):
+    for chunk in _chunk_list(case):
+        assert len(chunk) <= 500


### PR DESCRIPTION
The problem was that the directory created was done so using the UUID in
the url. Then we were doing `/v0/data/uuid?latest`, so the directory
name was the always the old UUID even if there was a new version.

Using the /files/versions endpoint we can tell the latest version of a
file before going to download it. Replacing the old list of UUIDs with
the new list of UUIDs with the newer versions in it. After that the download
process continues as normal.