### PR TITLE
[chore][DTT-105]: rename flags. change defaults

### DIFF
--- a/gdc_client/common/config.py
+++ b/gdc_client/common/config.py
@@ -4,7 +4,8 @@ import sys
 from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 
 from gdc_client.defaults import (
-    processes, USER_DEFAULT_CONFIG_LOCATION, HTTP_CHUNK_SIZE
+    processes, USER_DEFAULT_CONFIG_LOCATION, HTTP_CHUNK_SIZE, SAVE_INTERVAL,
+    UPLOAD_PART_SIZE
 )
 
 log = logging.getLogger('gdc-client')
@@ -29,6 +30,7 @@ class GDCClientConfigShared(object):
     setting_getters = {
         'server': ConfigParser.get,
         'http_chunk_size': ConfigParser.getint,
+        'upload_part_size': ConfigParser.getint,
         'save_interval': ConfigParser.getint,
         'dir': ConfigParser.get,
         'n_processes': ConfigParser.getint,
@@ -59,12 +61,12 @@ class GDCClientConfigShared(object):
         return {
             'common': {
                 'server': 'https://api.gdc.cancer.gov',
-                'http_chunk_size': HTTP_CHUNK_SIZE,
-                'save_interval': HTTP_CHUNK_SIZE,
                 'n_processes': processes,
             },
             'download': {
                 'dir': '.',
+                'save_interval': SAVE_INTERVAL,
+                'http_chunk_size': HTTP_CHUNK_SIZE,
                 'no_segment_md5sum': False,
                 'no_file_md5sum': False,
                 'no_verify': False,
@@ -76,6 +78,7 @@ class GDCClientConfigShared(object):
             },
             'upload': {
                 'path': '.',
+                'upload_part_size': UPLOAD_PART_SIZE,
                 'insecure': False,
                 'disable_multipart': False,
             },

--- a/gdc_client/defaults.py
+++ b/gdc_client/defaults.py
@@ -38,7 +38,10 @@ proxy_host = 'localhost'
 # proxy (on `proxy_host`) to traffic on the GDC api host
 proxy_port = 9000
 
-HTTP_CHUNK_SIZE = 1024 * 1024 * 1024  # 1 GiB
+HTTP_CHUNK_SIZE = 1024 * 1024  # 1 MB
+SAVE_INTERVAL = 1024 * 1024 * 1024  # 1 GiB
+# Part size for multipart uploads
+UPLOAD_PART_SIZE = 1024 * 1024 * 1024 # 1 GiB
 
 # The following file will contain superseded files information
 SUPERSEDED_INFO_FILENAME_TEMPLATE = re.compile(r'superseded_files[\d._]+.txt')

--- a/gdc_client/upload/parser.py
+++ b/gdc_client/upload/parser.py
@@ -13,9 +13,6 @@ log = logging.getLogger('gdc-upload')
 def validate_args(parser, args):
     """ Validate argparse namespace.
     """
-    if args.identifier:
-        log.warn('The use of the -i/--identifier flag has been deprecated.')
-
     if not args.token_file:
         parser.error('A token is required in order to upload.')
 
@@ -104,8 +101,6 @@ def config(parser, upload_defaults):
     parser.add_argument('--manifest', '-m',
                         type=argparse.FileType('r'),
                         help='Manifest which describes files to be uploaded')
-    parser.add_argument('--identifier', '-i', action='store_true',
-                        help='DEPRECATED')
     parser.add_argument('file_ids',
                         metavar='file_id', type=str,
                         nargs='*',

--- a/gdc_client/upload/parser.py
+++ b/gdc_client/upload/parser.py
@@ -52,7 +52,7 @@ def upload(parser, args):
         token=args.token_file,
         processes=args.n_processes,
         multipart=(not args.disable_multipart),
-        part_size=args.http_chunk_size,
+        upload_part_size=args.upload_part_size,
         server=args.server,
         files=files,
         verify=(not args.insecure),
@@ -85,7 +85,7 @@ def config(parser, upload_defaults):
     # TODO remove this and replace w/ top level host and port
     parser.add_argument('--server', '-s', type=str,
                         help='GDC API server address')
-    parser.add_argument('--http-chunk-size', '-c', type=int,
+    parser.add_argument('--upload-part-size', '-c', type=int,
                         help='Part size for multipart upload')
     parser.add_argument('-n', '--n-processes', type=int,
                         help='Number of client connections')

--- a/gdc_client/upload/parser.py
+++ b/gdc_client/upload/parser.py
@@ -13,6 +13,10 @@ log = logging.getLogger('gdc-upload')
 def validate_args(parser, args):
     """ Validate argparse namespace.
     """
+    if args.part_size:
+        log.warn('[--part-size] is DEPRECATED in favor of [--upload-part-size]')
+        args.upload_part_size = args.part_size
+
     if not args.token_file:
         parser.error('A token is required in order to upload.')
 
@@ -82,6 +86,8 @@ def config(parser, upload_defaults):
     # TODO remove this and replace w/ top level host and port
     parser.add_argument('--server', '-s', type=str,
                         help='GDC API server address')
+    parser.add_argument('--part-size', type=int,
+                        help='DEPRECATED in favor of [--upload-part-size]')
     parser.add_argument('--upload-part-size', '-c', type=int,
                         help='Part size for multipart upload')
     parser.add_argument('-n', '--n-processes', type=int,


### PR DESCRIPTION
After reviewing the code and discussing with Ian, we came to a conclusion that `http_chunk_size` serve different purposes for upload and download. To accommodate that we rename `--http-chunk-size` flag for upload to `--upload-part-size` and add corresponding default values in `defaults.py`.