### PR TITLE
[fix][DTT-121]: make sure superseded warning messages are logged only once

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ flask==1.0.2
 pytest==3.6.2
 pytest-cov==2.5.1
 codacy-coverage==1.3.11
+requests-mock==1.5.2

--- a/gdc_client/download/parser.py
+++ b/gdc_client/download/parser.py
@@ -94,12 +94,20 @@ def download(parser, args):
             break
         ids.add(i['id'])
 
-    # Query the api to get the latest version of a file according to the gdc.
-    # Replace the old list of uuids with the potentially newer list of uuids,
-    # then proceed with the rest of the program as normal.
-    if args.latest:
-        log.info('Downloading LATEST versions of files')
-        ids = get_latest_versions(args.server, ids)
+    # Query the api to get the latest version of a file(s) according to the gdc.
+    # Return OLD_ID => NEW_ID mapping
+    ids_map = get_latest_versions(args.server, ids)
+
+    for file_id, latest_id in ids_map.iteritems():
+        if args.latest:
+            log.info('Latest version for {} ==> {}'.format(file_id, latest_id))
+            continue
+        if latest_id is not None and file_id != latest_id:
+            log.warn('The file "{}" was superseded by "{}"'.format(
+                file_id, latest_id
+            ))
+
+    ids = ids_map.values() if args.latest else ids_map.keys()
 
     index_client = GDCIndexClient(args.server)
     client = get_client(args, index_client)

--- a/gdc_client/download/parser.py
+++ b/gdc_client/download/parser.py
@@ -98,6 +98,9 @@ def download(parser, args):
     # Return OLD_ID => NEW_ID mapping
     ids_map = get_latest_versions(args.server, ids)
 
+    if args.latest:
+        log.info('Downloading LATEST versions of files')
+
     for file_id, latest_id in ids_map.iteritems():
         if args.latest:
             log.info('Latest version for {} ==> {}'.format(file_id, latest_id))

--- a/gdc_client/query/versions.py
+++ b/gdc_client/query/versions.py
@@ -18,12 +18,12 @@ def get_latest_versions(url, uuids):
         uuids (list): list of UUIDs that might have a new version
 
     Returns:
-        list: list of uuids with potentially new versions
+        dict: mapping for user requested file UUIDs potentially new versions
     """
 
     uuids = list(uuids)
     versions_url = url + '/files/versions'
-    latest_versions = []
+    latest_versions = {}
 
     # Make multiple queries in an attempt to balance the load on the server.
     for chunk in _chunk_list(uuids):
@@ -35,8 +35,7 @@ def get_latest_versions(url, uuids):
             file_id = result.get("id")
             uuid = result.get('latest_id')
             if uuid:
-                logger.info("Latest version for {} ==> {}".format(file_id, uuid))
-                latest_versions.append(uuid)
+                latest_versions[file_id] = uuid
                 continue
             logger.info("No latest version found for {}".format(file_id))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lxml==4.2.1
 ndg-httpsclient==0.5.0
 pyasn1==0.4.3
 pyOpenSSL==18.0.0
--e git+https://github.com/LabAdvComp/parcel.git@d2670ce65ef6ea3dda0b1bab56a3342bed675958#egg=parcel
+-e git+https://github.com/LabAdvComp/parcel.git@f03ab838aa27cdb1f596854c863b31d22ef75ed1#egg=parcel
 PyYAML==3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ lxml==4.2.1
 ndg-httpsclient==0.5.0
 pyasn1==0.4.3
 pyOpenSSL==18.0.0
--e git+https://github.com/LabAdvComp/parcel.git@f03ab838aa27cdb1f596854c863b31d22ef75ed1#egg=parcel
+-e git+https://github.com/LabAdvComp/parcel.git@8cf5fe9922f3f3f1f9930c47783fc18c512d6b6a#egg=parcel
 PyYAML==3.12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,3 +101,14 @@ uuids = {
         'access': 'open',
     },
 }
+
+
+@pytest.fixture
+def versions_response(requests_mock):
+    def mock_response(url, ids, latest_ids):
+        requests_mock.post(url, json=[
+            {'id': file_id, 'latest_id': latest_id}
+            for file_id, latest_id in zip(ids, latest_ids)
+        ])
+
+    return mock_response

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -235,17 +235,6 @@ def test_chunk_list(case):
         assert len(chunk) <= 500
 
 
-@pytest.fixture
-def versions_response(requests_mock):
-    def mock_response(url, ids, latest_ids):
-        requests_mock.post(url, json=[
-            {'id': file_id, 'latest_id': latest_id}
-            for file_id, latest_id in zip(ids, latest_ids)
-        ])
-
-    return mock_response
-
-
 @pytest.mark.parametrize('ids, latest_ids, expected', [
     (['foo', 'bar'], ['foo', 'baz'], {'foo': 'foo', 'bar': 'baz'}),
     (['1', '2', '3'], ['a', 'b', 'c'], {'1': 'a', '2': 'b', '3': 'c'}),


### PR DESCRIPTION
* Pin `parcel` to a version where superseded info isn't logged
* Update `gdc_client.query.get_latest_versions` to return a mapping `OLD=>NEW` instead of a list
* Log superseded file info inside download client.
* Add unittests