### PR TITLE
TT-1093 set up tox for gdc-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ python:
 sudo: false
 
 install:
-  - pip install -r requirements.txt
-  - pip install -r dev-requirements.txt
-  - python setup.py install
-  - pip freeze
+  - pip install tox-travis
 
 script:
-  - python -m pytest -vv --cov=gdc_client --cov-report xml tests/
+  - tox 
   - python-codacy-coverage -r coverage.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ lxml==4.2.1
 ndg-httpsclient==0.5.0
 pyasn1==0.4.3
 pyOpenSSL==18.0.0
--e git+https://github.com/LabAdvComp/parcel.git@8cf5fe9922f3f3f1f9930c47783fc18c512d6b6a#egg=parcel
+-e git+https://github.com/coagulant/progressbar-python3.git#egg=progressbar-python3
+-e git+https://github.com/LabAdvComp/parcel.git#egg=parcel
 PyYAML==3.13

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist= py27, py3
+
+[testenv]
+deps=
+    -rrequirements.txt
+    -rdev-requirements.txt
+commands=
+    python setup.py install
+    pip freeze
+    python -m pytest -lvv --cov=gdc_client --cov-report xml tests/


### PR DESCRIPTION
Not finished
in Python 2, there is one test failing (test_download_tarfile)
in Python 3, there is a moduleNotFoundError: no module named server pertaining to the parcel module. I believe other modules simply had to import another library in order to deal with this issue. 