### PR TITLE
fix(logging): respect logging format for py3

### DIFF
--- a/gdc_client/log/log.py
+++ b/gdc_client/log/log.py
@@ -11,7 +11,7 @@ class LogFormatter(logging.Formatter):
     info_format = '%(msg)s'
 
 
-    def __init__(self, fmt='%(asctime)s - %(levelname)s: %(msg)s',
+    def __init__(self, fmt='%(asctime)s - %(levelname)s: %(msg)s', style='%',
                  color_off=False):
         logging.Formatter.__init__(self, fmt)
         self.color_off = color_off
@@ -19,29 +19,30 @@ class LogFormatter(logging.Formatter):
 
     def format(self, record):
         # Skip colored output if the flag is set
+        # TODO: color off does not respect other formatting
         if self.color_off:
             return logging.Formatter.format(self, record)
 
         # Save the original format
-        format_orig = self._fmt
+        format_orig = self._style._fmt
 
         # Replace the original format with one customized by logging level
         if record.levelno == logging.DEBUG:
-            self._fmt = LogFormatter.dbg_format
+            self._style._fmt = LogFormatter.dbg_format
 
         elif record.levelno == logging.INFO:
-            self._fmt = LogFormatter.info_format
+            self._style._fmt = LogFormatter.info_format
 
         elif record.levelno == logging.WARNING:
-            self._fmt = LogFormatter.warn_format
+            self._style._fmt = LogFormatter.warn_format
 
         elif record.levelno == logging.ERROR:
-            self._fmt = LogFormatter.err_format
+            self._style._fmt = LogFormatter.err_format
 
         result = logging.Formatter.format(self, record)
 
         # Restore the original format
-        self._fmt = format_orig
+        self._style._fmt = format_orig
 
         return result
 

--- a/gdc_client/log/log.py
+++ b/gdc_client/log/log.py
@@ -13,7 +13,7 @@ class LogFormatter(logging.Formatter):
 
     def __init__(self, fmt='%(asctime)s - %(levelname)s: %(msg)s', style='%',
                  color_off=False):
-        logging.Formatter.__init__(self, fmt)
+        logging.Formatter.__init__(self, fmt, style)
         self.color_off = color_off
 
 

--- a/gdc_client/log/parser.py
+++ b/gdc_client/log/parser.py
@@ -29,7 +29,7 @@ def setup_logging(args):
         f_handler.setFormatter(f_formatter)
         root.addHandler(f_handler)
 
-    # the requests library has it's own log statements, and it bundles itself without asking
+    # the requests library has its own log statements, and it bundles itself without asking
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger('urllib3').setLevel(logging.WARNING)
 


### PR DESCRIPTION
Logging in py3 uses the format set in `style` rather than `format`. See [source code](https://github.com/python/cpython/blob/d730719b094cb006711b1cd546927b863c173b31/Lib/logging/__init__.py#L533).