### PR TITLE
fix(subparsers): required

### DIFF
--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -76,6 +76,7 @@ if __name__ == '__main__':
         dest='command',
         help='for more information, specify -h after a command',
     )
+    subparsers.required = True
 
     download_subparser = subparsers.add_parser('download',
         parents=[template],
@@ -91,7 +92,9 @@ if __name__ == '__main__':
     upload.parser.config(upload_subparser, config_loader.to_dict('upload'))
 
     settings_subparser = subparsers.add_parser(
-        'settings', help='display default settings')
+        'settings',
+        help='display default settings',
+    )
     settings.parser.config(settings_subparser, conf_parser_args.config)
 
     # Parse and run.

--- a/gdc_client/argparser.py
+++ b/gdc_client/argparser.py
@@ -1,9 +1,0 @@
-import argparse
-from version import __version__ as version
-
-args = argparse.ArgumentParser(description=('GDC Command Line Client'))
-argparser = argparse.ArgumentParser()
-argparser.add_argument('--version', '-v', action='version',
-                       version='%(prog)s {0}'.format(version))
-
-subparsers = argparser.add_subparsers(help='sub-command help', dest='command')

--- a/gdc_client/settings/parser.py
+++ b/gdc_client/settings/parser.py
@@ -33,6 +33,7 @@ def resolve(config_file, args):
 def config(parser, config_file=None):
     parser.add_argument('--config', help=HELP, metavar='FILE')
     choices = parser.add_subparsers(title='Settings to display', dest='section')
+    choices.required = True
 
     download_choice = choices.add_parser('download', help='Display download settings')
     download_choice.add_argument('--config', help=HELP, metavar='FILE')


### PR DESCRIPTION
The usual way to do argparsing is something like:
```
# create the top-level parser
parser = argparse.ArgumentParser()
subparsers = parser.add_subparsers()

# create the parser for the "foo" command
parser_foo = subparsers.add_parser('foo')
parser_foo.add_argument('-x', type=int)

args = parser.parse_args('foo 1 -x 2'.split())
args.func(args)
```

Python3 [argparse.subparsers](https://docs.python.org/3/library/argparse.html#sub-commands) have their `required` flag set to `False` by default. The old 2.7 `parse_args` codepath would throw an error if we got [this far](https://github.com/python/cpython/blob/2.7/Lib/argparse.py#L1954) without finding any arguments, but the newer version [lacks that check](https://github.com/python/cpython/blob/master/Lib/argparse.py#L2071). That means that given a subparser not marked as `required==True`, given no arguments, the arg parsing will pass and return `args=args.Namespace({'commands': None})`. 

TL;DR: if you enter just a command with no args, you will end up getting a somewhat opaque `AttributeError: 'Namespace' object has no attribute 'func'` error in your last line instead of invoking the foo handler.

This is a pretty well known [bug/feature](https://stackoverflow.com/questions/22990977/why-does-this-argparse-code-behave-differently-between-python-2-and-3/22994500#22994500) and it seems marking the subparser as required is the easiest fix.

Also cleans up some dead code.

Addresses https://jira.opensciencedatacloud.org/browse/SV-1648