### PR TITLE
feat(DTT-154): Remove pyinstaller workaround

### DIFF
--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -24,6 +24,7 @@ import ndg.httpsclient
 import pyasn1
 ####################################################
 
+
 DESCRIPTION = '''
 The Genomic Data Commons Command Line Client
 '''

--- a/bin/package
+++ b/bin/package
@@ -88,7 +88,12 @@ print(gdc_client.version.__version__)")
 echo "Creating ${TARGET_ENVIRONMENT} package for version ${VERSION}..."
 
 # Create binary
-pyinstaller --clean --additional-hooks-dir=. --noconfirm --onefile -c gdc-client
+pyinstaller \
+    --clean \
+    --additional-hooks-dir=. \
+    --noconfirm \
+    --onefile \
+    -c gdc-client
 
 echo "Testing produced binary..."
 ./dist/$BINARY_NAME --help

--- a/gdc_client/parcel/download_stream.py
+++ b/gdc_client/parcel/download_stream.py
@@ -136,7 +136,7 @@ class DownloadStream(object):
             header['host'] = host
         return header
 
-    def request(self, headers=None, verify=False, close=False,
+    def request(self, headers=None, verify=True, close=False,
                 max_retries=16):
         """Make request for file and return the response.
 

--- a/gdc_client/parcel/utils.py
+++ b/gdc_client/parcel/utils.py
@@ -47,11 +47,16 @@ def get_pbar(file_id, maxval, start_val=0):
 
     """
     log.debug('Downloading {0}:'.format(file_id))
-    pbar = ProgressBar(widgets=[
-        Percentage(), ' ',
-        Bar(marker='#', left='[', right=']'), ' ',
-        ETA(), ' ', FileTransferSpeed(), ' '], maxval=maxval, fd=sys.stdout)
-    pbar.currval = start_val
+    pbar = ProgressBar(
+        widgets=[
+            Percentage(), ' ',
+            Bar(marker='#', left='[', right=']'), ' ',
+            ETA(), ' ',
+            FileTransferSpeed(), ' ',
+        ],
+        initial_value=start_val,
+        maxval=maxval,
+        fd=sys.stdout)
     pbar.start()
     return pbar
 
@@ -85,7 +90,7 @@ def set_file_length(path, length):
         return
     with open(path, 'wb') as f:
         f.seek(length-1)
-        f.write('\0')
+        f.write(b'\0')
         f.truncate()
 
 


### PR DESCRIPTION
Prior to the recent Python3 upgrade we used an older version of the
requests library. This library came with a `cacert.pem` file needed to
make https connections. This file was separated out into it's own
library called `certifi`, and PyInstaller added a hook to include this
file on build time. The original workaround assumed the cacert.pem file
existed in the requests folder of the temp directory made by PyInstaller.

The workaround is no longer needed because of the PyInstaller hook.

Other changes in this commit revolve around Python3, and progressbar2 fixes.

- `e.message` is no longer needed in Python3.
- progress bar library was changed from progressbar to progressbar2 and
the behavior changed slightly.
- Reorganized imports in upload/client.py to pep8 recommendations.
- Added default parameter of True on verify request for download.