### PR TITLE
Feat/dev 506 large file download

### DIFF
--- a/gdc_client/common/config.py
+++ b/gdc_client/common/config.py
@@ -40,7 +40,7 @@ class GDCClientConfigShared(object):
         "n_processes": ConfigParser.getint,
         "retry_amount": ConfigParser.getint,
         "wait_time": ConfigParser.getfloat,
-        "no_segment_md5sum": ConfigParser.getboolean,
+        "no_segment_md5sums": ConfigParser.getboolean,
         "no_file_md5sum": ConfigParser.getboolean,
         "no_verify": ConfigParser.getboolean,
         "no_related_files": ConfigParser.getboolean,
@@ -49,6 +49,7 @@ class GDCClientConfigShared(object):
         "insecure": ConfigParser.getboolean,
         "disable_multipart": ConfigParser.getboolean,
         "path": ConfigParser.get,
+        "latest": ConfigParser.getboolean,
     }
 
     def __init__(self, config_path=None):
@@ -71,7 +72,7 @@ class GDCClientConfigShared(object):
                 "dir": ".",
                 "save_interval": SAVE_INTERVAL,
                 "http_chunk_size": HTTP_CHUNK_SIZE,
-                "no_segment_md5sum": False,
+                "no_segment_md5sums": False,
                 "no_file_md5sum": False,
                 "no_verify": False,
                 "no_related_files": False,
@@ -79,6 +80,7 @@ class GDCClientConfigShared(object):
                 "no_auto_retry": False,
                 "retry_amount": 1,
                 "wait_time": 5.0,
+                "latest": False,
             },
             "upload": {
                 "path": ".",

--- a/gdc_client/exceptions.py
+++ b/gdc_client/exceptions.py
@@ -1,3 +1,6 @@
 class ClientError(Exception):
-    """ Base client error.
-    """
+    """Base client error."""
+
+
+class MD5ValidationError(Exception):
+    """Base MD5 validation error."""

--- a/gdc_client/parcel/client.py
+++ b/gdc_client/parcel/client.py
@@ -110,7 +110,7 @@ class Client(object):
 
         log.debug("Download complete" + rate_info)
 
-    def validate_file_md5sum(self, stream):
+    def validate_file_md5sum(self, stream, file_path):
 
         if not stream.check_file_md5sum:
             log.debug("checksum validation disabled")
@@ -126,7 +126,7 @@ class Client(object):
                 "Cannot validate this file since the server did not provide an md5sum. Use the '--no-file-md5sum' option to ignore this error."
             )
 
-        if utils.md5sum_whole_file(stream.path) != stream.md5sum:
+        if utils.md5sum_whole_file(file_path) != stream.md5sum:
             raise Exception("File checksum is invalid")
 
     def download_files(self, urls, *args, **kwargs):
@@ -158,10 +158,11 @@ class Client(object):
 
             # Download file
             try:
+                # validate temporary file before renaming to permanent file location
                 self.parallel_download(stream)
+                self.validate_file_md5sum(stream, stream.temp_path)
                 if os.path.isfile(stream.temp_path):
                     utils.remove_partial_extension(stream.temp_path)
-                self.validate_file_md5sum(stream)
                 downloaded.append(url)
 
             # Handle file download error, store error to print out later

--- a/gdc_client/parcel/client.py
+++ b/gdc_client/parcel/client.py
@@ -207,20 +207,21 @@ class Client(object):
                 try:
                     segment = producer.q_work.get()
                     if segment is None:
-                        return log.debug("Producer returned with no more work")
+                        log.debug("Producer returned with no more work")
+                        return
                     stream.write_segment(segment, producer.q_complete)
-                    # write_segment completed successfully, send sentinal value
+                    # write_segment completed successfully, send sentinel value
                     # to master process to indicate a task was completed
                     producer.q_complete.put(None)
                 except Exception as e:
-                    # send sentinal value to master process even though
+                    # send sentinel value to master process even though
                     # write_segment failed to indicate a task is "finished"
                     producer.q_complete.put(None)
                     if self.debug:
                         raise
                     else:
                         log.error("Download aborted: {0}".format(str(e)))
-                        # worker needs to stay alive until final sentinal value
+                        # worker needs to stay alive until final sentinel value
                         # from master process is received
                         continue
 

--- a/gdc_client/parcel/segment.py
+++ b/gdc_client/parcel/segment.py
@@ -124,8 +124,18 @@ class SegmentProducer(object):
         if corrupt_segments:
             log.warning("Redownloading {0} corrupt segments.".format(corrupt_segments))
 
-    def recover_intervals(self):
-        """Recreate list of completed intervals and calculate remaining work pool"""
+    def recover_intervals(self) -> bool:
+        """Recreate list of completed intervals and calculate remaining work pool
+
+        This method checks the status of the following files:
+            - state_file (*.parcel)
+            - download_file
+            - partial temporary file (*.partial)
+
+        Returns:
+            bool: True if recovery occured, otherwise False (which indicates that
+            the a complete retry of the file download will occur)
+        """
         state_file_exists = os.path.isfile(self.download.state_path)
         download_file_exists = os.path.isfile(self.download.path)
         temporary_file_exists = os.path.isfile(self.download.temp_path)

--- a/gdc_client/parcel/segment.py
+++ b/gdc_client/parcel/segment.py
@@ -191,7 +191,7 @@ class SegmentProducer(object):
                 validate_file_md5sum(self.download, self.download.path)
             except Exception as e:
                 log.error(
-                    "MD5 sum of downloaded file is incorrect due to following reason: {0}. Proceeding to restart entire download".format(
+                    "MD5 check of downloaded file failed due to following reason: {0}. Proceeding to restart entire download".format(
                         str(e)
                     )
                 )

--- a/gdc_client/parcel/segment.py
+++ b/gdc_client/parcel/segment.py
@@ -125,7 +125,7 @@ class SegmentProducer(object):
             log.warning("Redownloading {0} corrupt segments.".format(corrupt_segments))
 
     def recover_intervals(self):
-        """Recreate list of completed intervals adcalculate remaining work pool"""
+        """Recreate list of completed intervals and calculate remaining work pool"""
         state_file_exists = os.path.isfile(self.download.state_path)
         download_file_exists = os.path.isfile(self.download.path)
         temporary_file_exists = os.path.isfile(self.download.temp_path)

--- a/gdc_client/parcel/segment.py
+++ b/gdc_client/parcel/segment.py
@@ -56,6 +56,7 @@ class SegmentProducer(object):
         self.download = download
         self.n_procs = n_procs
         self.pbar = None
+        self.total_tasks = 0
 
         # Initialize producer
         self.load_state()

--- a/gdc_client/parcel/segment.py
+++ b/gdc_client/parcel/segment.py
@@ -190,6 +190,7 @@ class SegmentProducer(object):
             log.debug("File is complete, will not attempt to re-download file.")
             # downloaded file is correct, set done flag in SegmentProducer
             self.done = True
+            self.work_pool = IntervalTree()
             return True
 
         if not temporary_file_exists:

--- a/gdc_client/parcel/segment.py
+++ b/gdc_client/parcel/segment.py
@@ -351,7 +351,7 @@ class SegmentProducer(object):
                 while since_save < self.save_interval:
                     interval = self.q_complete.get()
                     # Once a process completes a tasks (sucess or failure),
-                    # it will return a sentinal value (None) to main process
+                    # it will return a sentinel value (None) to main process
                     # to indicate that a task was completed
                     if interval is None:
                         num_tasks_completed += 1

--- a/gdc_client/parcel/utils.py
+++ b/gdc_client/parcel/utils.py
@@ -25,6 +25,7 @@ from progressbar import (
 )
 
 from gdc_client.exceptions import MD5ValidationError
+from gdc_client.parcel.download_stream import DownloadStream
 
 # Logging
 log = logging.getLogger("utils")
@@ -190,7 +191,16 @@ def md5sum_whole_file(fname):
     return hash_md5.hexdigest()
 
 
-def validate_file_md5sum(stream, file_path):
+def validate_file_md5sum(stream: DownloadStream, file_path: str) -> None:
+    """Function to validate md5sum for given file if prerequisite checks pass
+
+    Args:
+        stream: initialized DownloadStream object
+        file_path: file to validate
+    Raises:
+        MD5ValidationError: if correct DownloadStream flags are not set or
+                            md5sum does not have given md5sum
+    """
     if not stream.check_file_md5sum:
         log.debug("checksum validation disabled")
         return

--- a/gdc_client/parcel/utils.py
+++ b/gdc_client/parcel/utils.py
@@ -46,10 +46,7 @@ def check_transfer_size(actual, expected):
 
 
 def get_file_transfer_pbar(
-    file_id: str,
-    maxval: int,
-    start_val: int = 0,
-    desc: str = "Downloading",
+    file_id: str, maxval: int, start_val: int = 0, desc: str = "Downloading",
 ) -> ProgressBar:
     """Create and initialize a custom progressbar
 
@@ -86,12 +83,7 @@ def get_file_transfer_pbar(
 def get_percentage_pbar(maxval: int):
     """Create and initialize a simple percentage progressbar"""
     pbar = ProgressBar(
-        widgets=[
-            Percentage(),
-            " ",
-            Bar(marker="#", left="[", right="]"),
-            " ",
-        ],
+        widgets=[Percentage(), " ", Bar(marker="#", left="[", right="]"), " ",],
         max_value=maxval,
     )
     pbar.start()
@@ -194,6 +186,23 @@ def md5sum_whole_file(fname):
             hash_md5.update(chunk)
 
     return hash_md5.hexdigest()
+
+
+def validate_file_md5sum(stream, file_path):
+    if not stream.check_file_md5sum:
+        log.debug("checksum validation disabled")
+        return
+
+    log.debug("Validating checksum...")
+    if not stream.is_regular_file:
+        raise Exception("Not a regular file")
+
+    if not stream.md5sum:
+        raise Exception(
+            "Cannot validate this file since the server did not provide an md5sum. Use the '--no-file-md5sum' option to ignore this error."
+        )
+    if md5sum_whole_file(file_path) != stream.md5sum:
+        raise Exception("File checksum is invalid")
 
 
 @contextmanager

--- a/gdc_client/parcel/utils.py
+++ b/gdc_client/parcel/utils.py
@@ -24,6 +24,8 @@ from progressbar import (
     ProgressBar,
 )
 
+from gdc_client.exceptions import MD5ValidationError
+
 # Logging
 log = logging.getLogger("utils")
 
@@ -195,14 +197,14 @@ def validate_file_md5sum(stream, file_path):
 
     log.debug("Validating checksum...")
     if not stream.is_regular_file:
-        raise Exception("Not a regular file")
+        raise MD5ValidationError("Not a regular file")
 
     if not stream.md5sum:
-        raise Exception(
+        raise MD5ValidationError(
             "Cannot validate this file since the server did not provide an md5sum. Use the '--no-file-md5sum' option to ignore this error."
         )
     if md5sum_whole_file(file_path) != stream.md5sum:
-        raise Exception("File checksum is invalid")
+        raise MD5ValidationError("File checksum is invalid")
 
 
 @contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def generate_metadata_dict(
 
 
 def get_big_content(n: int) -> str:
-    return str(n) * (HTTP_CHUNK_SIZE) * 5
+    return str(n) * (HTTP_CHUNK_SIZE + 1)
 
 
 uuids = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def generate_metadata_dict(
 
 
 def get_big_content(n: int) -> str:
-    return str(n) * (HTTP_CHUNK_SIZE + 1)
+    return str(n) * (HTTP_CHUNK_SIZE) * 5
 
 
 uuids = {

--- a/tests/test_parcel_utils.py
+++ b/tests/test_parcel_utils.py
@@ -1,0 +1,90 @@
+import logging
+from unittest import mock
+
+import pytest
+
+from gdc_client.parcel import utils
+from gdc_client import exceptions
+
+
+@mock.patch("gdc_client.parcel.utils.md5sum_whole_file")
+def test__validate_file_md5sum(mock_md5sum_whole_file):
+    stream = mock.MagicMock()
+    check_file_md5sum_mock = mock.PropertyMock(return_value=True)
+    is_regular_file_mock = mock.PropertyMock(return_value=True)
+    md5sum_mock = mock.PropertyMock(
+        return_value="d47b127bc2de2d687ddc82dac354c415"  # pragma: allowlist secret
+    )
+    type(stream).check_file_md5sum = check_file_md5sum_mock
+    type(stream).is_regular_file = is_regular_file_mock
+    type(stream).md5sum = md5sum_mock
+    mock_md5sum_whole_file.return_value = (
+        "d47b127bc2de2d687ddc82dac354c415"  # pragma: allowlist secret
+    )
+    file_path = "test.txt"
+
+    utils.validate_file_md5sum(stream, file_path)
+
+    assert check_file_md5sum_mock.call_count == 1
+    assert is_regular_file_mock.call_count == 1
+    assert md5sum_mock.call_count == 2
+
+
+def test__validate_file_md5sum_negative_validate_disabled(caplog):
+    stream = mock.MagicMock()
+    check_file_md5sum_mock = mock.PropertyMock(return_value=False)
+    type(stream).check_file_md5sum = check_file_md5sum_mock
+    file_path = "test.txt"
+
+    with caplog.at_level(logging.DEBUG):
+        utils.validate_file_md5sum(stream, file_path)
+
+        check_file_md5sum_mock.assert_called_once_with()
+        assert caplog.records[0].message == "checksum validation disabled"
+
+
+@pytest.mark.parametrize(
+    "properties, expected",
+    [
+        (dict(check_file_md5sum=True, is_regular_file=False), "Not a regular file"),
+        (
+            dict(check_file_md5sum=True, is_regular_file=True, md5sum=None),
+            (
+                "Cannot validate this file since the server "
+                "did not provide an md5sum. Use the "
+                "'--no-file-md5sum' option to ignore this error."
+            ),
+        ),
+        (
+            dict(
+                check_file_md5sum=True,
+                is_regular_file=True,
+                md5sum="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ),
+            "File checksum is invalid",
+        ),
+    ],
+    ids=["not_regular_file", "no_server_md5sum", "incorrect_md5sum"],
+)
+@mock.patch("gdc_client.parcel.utils.md5sum_whole_file")
+def test__validate_file_md5sum_negative_validation_errors(
+    mock_md5sum_whole_file, properties: dict, expected: str
+):
+    stream = mock.MagicMock(**properties)
+    file_path = "test.txt"
+    mock_md5sum_whole_file.return_value = (
+        "d47b127bc2de2d687ddc82dac354c415"  # pragma: allowlist secret
+    )
+
+    with pytest.raises(exceptions.MD5ValidationError, match=r"{}".format(expected)):
+        utils.validate_file_md5sum(stream, file_path)
+
+
+def test__md5sum_whole_file():
+    with mock.patch(
+        "builtins.open", mock.mock_open(read_data=b"A" * 1024)
+    ) as mock_file:
+        assert utils.md5sum_whole_file("test.txt") == (
+            "d47b127bc2de2d687ddc82dac354c415"  # pragma: allowlist secret
+        )
+        mock_file.assert_called_once_with("test.txt", "rb")

--- a/tests/test_segment_producer.py
+++ b/tests/test_segment_producer.py
@@ -54,7 +54,7 @@ def mock_download_stream(monkeypatch, setup_directories: typing.NamedTuple):
 
     download_stream = stream.DownloadStream(
         url="https://localhost:80/data/test",
-        directory=setup_directories.base_directory.resolve(),
+        directory=str(setup_directories.base_directory.resolve()),
         token=None,
     )
     download_stream.init()

--- a/tests/test_segment_producer.py
+++ b/tests/test_segment_producer.py
@@ -1,0 +1,197 @@
+import collections
+import logging
+import os
+import pathlib
+import pickle
+import pytest
+import typing
+
+import intervaltree as itree
+
+import gdc_client.parcel.segment as segment
+import gdc_client.parcel.download_stream as stream
+import gdc_client.parcel.utils as utils
+
+directories_tuple = collections.namedtuple(
+    "directories", ["base_directory", "data_directory", "state_directory"]
+)
+
+data_info = collections.namedtuple("data_info", ["data", "md5sum"])
+
+
+@pytest.fixture()
+def setup_directories(tmp_path: pathlib.Path):
+    data_directory = tmp_path.joinpath("test")
+    state_directory = tmp_path.joinpath("test/logs")
+    tmp_path.mkdir(exist_ok=True)
+    data_directory.mkdir(exist_ok=True)
+    state_directory.mkdir(exist_ok=True)
+
+    return directories_tuple(tmp_path, data_directory, state_directory)
+
+
+@pytest.fixture()
+def complete_data():
+    data = b"A" * 1024
+    return data_info(data, utils.md5sum(data))
+
+
+@pytest.fixture()
+def incomplete_data():
+    data = b"A" * 512
+    return data_info(data, utils.md5sum(data))
+
+
+@pytest.fixture()
+def mock_download_stream(monkeypatch, setup_directories: typing.NamedTuple):
+    def mock_init(self):
+        self.initialized = True
+        self.name = "test.txt"
+        self.size = 1024
+        self.md5sum = "d47b127bc2de2d687ddc82dac354c415"
+
+    monkeypatch.setattr(stream.DownloadStream, "init", mock_init)
+
+    download_stream = stream.DownloadStream(
+        url="https://localhost:80/data/test",
+        directory=setup_directories.base_directory.resolve(),
+        token=None,
+    )
+    download_stream.init()
+
+    return download_stream
+
+
+@pytest.fixture(autouse=True)
+def mock_schedule(monkeypatch):
+    """Mock SegmentProducer.schedule() to not immediately fill up work queue with Intervals"""
+
+    def mock_schedule(self):
+        return
+
+    monkeypatch.setattr(segment.SegmentProducer, "schedule", mock_schedule)
+
+
+@pytest.fixture()
+def mock_complete_download_file(
+    setup_directories: typing.NamedTuple, complete_data: typing.NamedTuple
+):
+    write_data_file(setup_directories.data_directory, "test.txt", complete_data.data)
+
+
+@pytest.fixture()
+def mock_incomplete_download_file(
+    setup_directories: typing.NamedTuple, incomplete_data: typing.NamedTuple
+):
+    write_data_file(setup_directories.data_directory, "test.txt", incomplete_data.data)
+
+
+@pytest.fixture()
+def mock_temporary_file(
+    setup_directories: typing.NamedTuple, incomplete_data: typing.NamedTuple
+):
+    write_data_file(
+        setup_directories.data_directory, "test.txt.partial", incomplete_data.data
+    )
+
+
+@pytest.fixture()
+def mock_complete_state_file(
+    setup_directories: typing.NamedTuple, complete_data: typing.NamedTuple
+):
+    write_state_file(
+        setup_directories.state_directory, "test.txt.parcel", complete_data
+    )
+
+
+@pytest.fixture()
+def mock_incomplete_state_file(
+    setup_directories: typing.NamedTuple, incomplete_data: typing.NamedTuple
+):
+    write_state_file(
+        setup_directories.state_directory, "test.txt.parcel", incomplete_data
+    )
+
+
+def write_data_file(directory: pathlib.Path, file_name: str, data: bytes):
+    file_path = directory.joinpath(file_name)
+    with file_path.open("wb") as f:
+        f.write(data)
+
+
+def write_state_file(directory: pathlib.Path, file_name: str, data: typing.NamedTuple):
+    file_path = directory.joinpath(file_name)
+    interval = itree.Interval(0, len(data.data), {"md5sum": data.md5sum})
+    completed = itree.IntervalTree([interval])
+    with file_path.open("wb") as f:
+        pickle.dump(completed, f)
+
+
+def test_load_state_no_state_file(
+    # test when no state file is present
+    mock_download_stream: stream.DownloadStream,
+    complete_data: typing.NamedTuple,
+):
+    producer = segment.SegmentProducer(mock_download_stream, 2)
+    assert os.path.isfile(mock_download_stream.temp_path)
+    assert len(producer.completed.items()) == 0
+    intervals = list(producer.work_pool.items())
+    assert len(intervals) == 1
+    assert intervals[0].begin == 0
+    assert intervals[0].end == len(complete_data.data)
+    assert producer.done == False
+
+
+@pytest.mark.usefixtures("mock_complete_state_file", "mock_complete_download_file")
+def test_load_state_complete_download_exists(
+    mock_download_stream: stream.DownloadStream, complete_data: typing.NamedTuple
+):
+    # test when state file is present and download file is present and complete
+    producer = segment.SegmentProducer(mock_download_stream, 2)
+    assert not os.path.isfile(mock_download_stream.temp_path)
+    assert len(producer.work_pool.items()) == 0
+    intervals = list(producer.completed.items())
+    assert len(intervals) == 1
+    assert intervals[0].begin == 0
+    assert intervals[0].end == len(complete_data.data)
+    assert intervals[0].data["md5sum"] == complete_data.md5sum
+    assert producer.done == True
+
+
+@pytest.mark.usefixtures("mock_incomplete_state_file", "mock_incomplete_download_file")
+def test_load_state_incomplete_download_exists(
+    # test when state file is present and download file is present and is incomplete
+    mock_download_stream: stream.DownloadStream,
+    complete_data: typing.NamedTuple,
+    incomplete_data: typing.NamedTuple,
+):
+    producer = segment.SegmentProducer(mock_download_stream, 2)
+    assert os.path.isfile(mock_download_stream.temp_path)
+    assert len(producer.completed.items()) == 0
+    intervals = list(producer.work_pool.items())
+    assert len(intervals) == 1
+    assert intervals[0].begin == 0
+    assert intervals[0].end == len(complete_data.data)
+    assert producer.done == False
+
+
+@pytest.mark.usefixtures("mock_incomplete_state_file", "mock_temporary_file")
+def test_load_state_state_temp_exist(
+    mock_download_stream: stream.DownloadStream,
+    complete_data: typing.NamedTuple,
+    incomplete_data: typing.NamedTuple,
+):
+    # test when state file is present and temporary file is present
+    producer = segment.SegmentProducer(mock_download_stream, 2)
+    assert os.path.isfile(mock_download_stream.temp_path)
+    # check that completed intervals are correct
+    intervals = list(producer.completed.items())
+    assert len(intervals) == 1
+    assert intervals[0].begin == 0
+    assert intervals[0].end == len(incomplete_data.data)
+    assert intervals[0].data["md5sum"] == incomplete_data.md5sum
+    intervals = list(producer.work_pool.items())
+    assert len(intervals) == 1
+    assert intervals[0].begin == len(incomplete_data.data)
+    assert intervals[0].end == len(complete_data.data)
+    assert producer.done == False


### PR DESCRIPTION
details can be found in the ticket as to what problems are addressed here:
https://jira.opensciencedatacloud.org/browse/DEV-506

One thing that would change with this PR is the state of the partial file. Before this change, even if a download failed, the partial file would be renamed to the final file name. With this change, in the event that all the download retries of a particular file failed, the partial file would be left in the directory and not renamed. The next run of DTT would see this file, see that it is incomplete, and load state accordingly. The full scope of the change can be found in the ticket