### PR TITLE
Update gdc-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Building on Windows requires the installation of [git](https://git-scm.com/downl
 cd bin
 # Then just execute the package script. The result will be a zip file containing your executable.
 ./package
+# Or you can choose to install it use conda env
+conda create -n gdc python=3.7
+conda activate gdc
+git clone https://github.com/NCI-GDC/gdc-client
+cd gdc-client
+pip install -r requirements.txt
+vim bin/gdc-client #修改 import OpenSSL为import ssl
+python setup.py install 2>&1 | tee -a install.log
 ```
 
 ## Executing unit tests

--- a/bin/gdc-client
+++ b/bin/gdc-client
@@ -15,9 +15,14 @@ from gdc_client.common.config import GDCClientConfigShared, GDCClientArgumentPar
 ####################################################
 # These packages are important but PyInstaller won't
 # bundle them unless they are imported
+# For CentOS with python3.7, pyOpenSSL version 18.0.0,
+# you need to use "import ssl" instead of "import OpenSSL"
+# to solve the error about "sslv3_server_method" occured  
+# when you try to run gdc-client 
 import cffi
 import cryptography
-import OpenSSL
+#import OpenSSL   
+import ssl
 import ndg.httpsclient
 import pyasn1
 


### PR DESCRIPTION
Try to solve the error occured with python3.7 as below
Traceback (most recent call last):
  File "gdc-client", line 20, in <module>
    import OpenSSL
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "OpenSSL/__init__.py", line 8, in <module>
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "OpenSSL/crypto.py", line 16, in <module>
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "OpenSSL/_util.py", line 6, in <module>
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "cryptography/hazmat/bindings/openssl/binding.py", line 15, in <module>
ImportError: /tmp/_MEIIJH9Dd/cryptography/hazmat/bindings/_openssl.abi3.so: undefined symbol: SSLv3_server_method 