### PR TITLE
DEV-2991: update upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
       - develop
       - release/**
       - hotfix/**
-      - feat/DEV-2991-update-upload-artifact-version
     tags:
       - '*'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
       - develop
       - release/**
       - hotfix/**
+      - feat/DEV-2991-update-upload-artifact-version
     tags:
       - '*'
 
@@ -47,7 +48,7 @@ jobs:
           . ./package
           echo "GDC_CLIENT_ZIP=$GDC_CLIENT_ZIP" >> $GITHUB_ENV
         shell: bash
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.GDC_CLIENT_ZIP }}-py${{ matrix.python }}-${{ matrix.os }}
           path: bin/gdc-client_*.zip


### PR DESCRIPTION
v1 and v2 of the upload-artifact action have been deprecated. This change upgrades to the latest version, v4.